### PR TITLE
Changes for sensinact adapter

### DIFF
--- a/org.gecko.weather.dwd.forecast/README.MD
+++ b/org.gecko.weather.dwd.forecast/README.MD
@@ -3,7 +3,7 @@
 ## Introduction
 
 The forecast fetcher is currently activated for MOSMIX (https://www.dwd.de/DE/leistungen/met_verfahren_mosmix/met_verfahren_mosmix.html)[https://www.dwd.de/DE/leistungen/met_verfahren_mosmix/met_verfahren_mosmix.html].
-The 'WeatherReportSearch' service starts the configurable cron based `org.gecko.weathcer.dwd.fc.impl.DWDMOSMIXStationForecastFetcher`. This needs a station identifier which can be retrieved through the (station service)[../org.gecko.weather.dwd.stations/README.MD] / station search.
+The `WeatherReportSearch` service starts the configurable cron based on `org.gecko.weathcer.dwd.fc.impl.DWDMOSMIXStationForecastFetcher`. This needs a station identifier which can be retrieved through the [station service](../org.gecko.weather.dwd.stations/README.MD) / station search.
 
 In this implementation the configuration for the Station-Forecast-Fetcher is created when triggering a command: `org.gecko.weathcer.dwd.fc.cmd.MOSMIXForecastCommand`. To automatically schedule the cron job, just create a corresponding configuration.
 

--- a/org.gecko.weather.dwd.forecast/src/org/gecko/weather/dwd/fc/impl/WeatherReportIndexservice.java
+++ b/org.gecko.weather.dwd.forecast/src/org/gecko/weather/dwd/fc/impl/WeatherReportIndexservice.java
@@ -43,6 +43,7 @@ import org.gecko.weather.dwd.fc.helper.ReportIndexHelper;
 import org.gecko.weather.model.weather.WeatherPackage;
 import org.gecko.weather.model.weather.WeatherReport;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
@@ -53,7 +54,7 @@ import org.osgi.service.event.annotations.RequireEventAdmin;
  * @author Mark Hoffmann
  * @since 15.09.2024
  */
-@Component
+@Component(name = "WeatherReportIndex", configurationPid = "WeatherReportIndex", configurationPolicy = ConfigurationPolicy.OPTIONAL)
 @RequireEventAdmin
 public class WeatherReportIndexservice implements WeatherReportIndex {
 

--- a/org.gecko.weather.dwd.forecast/src/org/gecko/weather/dwd/fc/impl/WeatherReportSearchService.java
+++ b/org.gecko.weather.dwd.forecast/src/org/gecko/weather/dwd/fc/impl/WeatherReportSearchService.java
@@ -49,12 +49,13 @@ import org.gecko.weather.model.weather.WeatherPackage;
 import org.gecko.weather.model.weather.WeatherReport;
 import org.osgi.service.component.ComponentServiceObjects;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * This is a sample Search Service to retrieve the objects from the index
  */
-@Component
+@Component(name = "WeatherReportSearch", configurationPid = "WeatherReportSearch", configurationPolicy = ConfigurationPolicy.OPTIONAL)
 @RequireEMF
 public class WeatherReportSearchService implements WeatherReportSearch {
 

--- a/org.gecko.weather.dwd.stations/README.MD
+++ b/org.gecko.weather.dwd.stations/README.MD
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Fetches two different station list from the DWD. This is done by the `org.gecko.weathcer.dwd.impl.DWDStationListFetcher` that is auotmatically scheduled on application *reboot*.
+Fetches two different station lists from the DWD. This is done by the `org.gecko.weathcer.dwd.impl.DWDStationListFetcher` that is automatically scheduled on application *reboot*.
 
 It uses stations from:
 
@@ -15,7 +15,7 @@ The retrieved stations are indexed in-memory and can be found using the `org.gec
 
 ### Search Station By Name
 
-Gogo Command: *stationbyname*
+Gogo Command: *stationByName*
 
 **Parameter:** 
 
@@ -29,7 +29,7 @@ Search for all station with similar name *“Erf”*
 
 ### Search Station Nearby
 
-Gogo Command: *stationbylocation*
+Gogo Command: *stationByLocation*
 
 **Parameter: **
 
@@ -40,8 +40,8 @@ Gogo Command: *stationbylocation*
 
 Searches for a station near the given position in a radius of 20km: 
 
-`g! stationbylocation -p 51.0,11.03 -r 20` 
+`g! stationByLocation -p 51.0,11.03 -r 20` 
 
 Search for a station near the given position using the default radius of 30km:
 
-`g! stationbylocation -p 51.0,11.03` 
+`g! stationByLocation -p 51.0,11.03` 

--- a/org.gecko.weather.model/model/dwd-weather.genmodel
+++ b/org.gecko.weather.model/model/dwd-weather.genmodel
@@ -3,8 +3,8 @@
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" copyrightText="Copyright (c) 2012 - 2024 Data In Motion and others.&#xA;All rights reserved. &#xA;&#xA;This program and the accompanying materials are made&#xA;available under the terms of the Eclipse Public License 2.0&#xA;which is available at https://www.eclipse.org/legal/epl-2.0/&#xA;&#xA;SPDX-License-Identifier: EPL-2.0&#xA;&#xA;Contributors:&#xA;     Mark Hoffmann - initial API and implementation"
     modelDirectory="/org.gecko.weather.model/src" modelPluginID="org.gecko.weather.model"
     modelName="DWDWeather" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
-    importerID="org.eclipse.emf.importer.ecore" complianceLevel="17.0" copyrightFields="false"
-    operationReflection="true" importOrganizing="true" oSGiCompatible="true">
+    importerID="org.eclipse.emf.importer.ecore" complianceLevel="17.0" suppressGenModelAnnotations="false"
+    copyrightFields="false" operationReflection="true" importOrganizing="true" oSGiCompatible="true">
   <foreignModel>dwd-weather.ecore</foreignModel>
   <genPackages prefix="Weather" basePackage="org.gecko.weather.model" resource="XMI"
       disposableProviderFactory="true" ecorePackage="dwd-weather.ecore#/">

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/WeatherPackage.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/WeatherPackage.java
@@ -36,6 +36,7 @@ import org.osgi.annotation.versioning.ProviderType;
  * <!-- end-user-doc -->
  * @see org.gecko.weather.model.weather.WeatherFactory
  * @model kind="package"
+ *        annotation="http://www.eclipse.org/emf/2002/GenModel copyrightText='Copyright (c) 2012 - 2024 Data In Motion and others.\nAll rights reserved. \n\nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0\n\nContributors:\n     Mark Hoffmann - initial API and implementation' complianceLevel='17.0' oSGiCompatible='true' modelName='DWDWeather' basePackage='org.gecko.weather.model' resource='XMI'"
  * @generated
  */
 @ProviderType

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/WeatherPackageImpl.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/WeatherPackageImpl.java
@@ -1344,6 +1344,324 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 
 		// Create resource
 		createResource(eNS_URI);
+
+		// Create annotations
+		// http://www.eclipse.org/emf/2002/GenModel
+		createGenModelAnnotations();
+	}
+
+	/**
+	 * Initializes the annotations for <b>http://www.eclipse.org/emf/2002/GenModel</b>.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void createGenModelAnnotations() {
+		String source = "http://www.eclipse.org/emf/2002/GenModel";
+		addAnnotation
+		  (this,
+		   source,
+		   new String[] {
+			   "copyrightText", "Copyright (c) 2012 - 2024 Data In Motion and others.\nAll rights reserved. \n\nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0\n\nContributors:\n     Mark Hoffmann - initial API and implementation",
+			   "complianceLevel", "17.0",
+			   "oSGiCompatible", "true",
+			   "modelName", "DWDWeather",
+			   "basePackage", "org.gecko.weather.model",
+			   "resource", "XMI"
+		   });
+		addAnnotation
+		  (getWeatherReport_Station(),
+		   source,
+		   new String[] {
+			   "documentation", "Station the measurments are for. This is usually the exact location the report belongs to"
+		   });
+		addAnnotation
+		  (getWeatherReport_Astrotime(),
+		   source,
+		   new String[] {
+			   "documentation", "Additional astro time information for this report, like sunset und sunrise times for the report day"
+		   });
+		addAnnotation
+		  (getWeatherReport_WeatherStation(),
+		   source,
+		   new String[] {
+			   "documentation", "The next official (DWD) weather station closest to the \'station\'. This is the official weather station most measurement com from"
+		   });
+		addAnnotation
+		  (mosmixsWeatherReportEClass,
+		   source,
+		   new String[] {
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_WindDirection(),
+		   source,
+		   new String[] {
+			   "documentation", "Wind direction: 0..360 Degrees (DD)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_WindSpeed(),
+		   source,
+		   new String[] {
+			   "documentation", "Wind speed: m/s (FF)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_WindGustLastHour(),
+		   source,
+		   new String[] {
+			   "documentation", "Maximum wind gust within the last hour: m/s (FX1)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_WindGustLastThreeHours(),
+		   source,
+		   new String[] {
+			   "documentation", "Maximum wind gust within the last 3 hours: m/s (FX3)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_WindGustMaxLast12Hours(),
+		   source,
+		   new String[] {
+			   "documentation", "Maximum wind gust within the last 12 hours: m/s (FXh)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_WindGustProb25(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability of wind gusts >= 25kn within the last 12 hours: 0..100% (FXh25)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_WindGustProb40(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability of wind gusts >= 40kn within the last 12 hours: 0..100% (FXh40)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_WindGustProb55(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability of wind gusts >= 55kn within the last 12 hours: 0..100% (FXh55)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_CloudCoverTotal(),
+		   source,
+		   new String[] {
+			   "documentation", "Total cloud cover: 0..100% (N)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_CloudCoverBelow500(),
+		   source,
+		   new String[] {
+			   "documentation", "Cloud cover below 500 ft.: 0..100% (N05)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_CloudCoverEffective(),
+		   source,
+		   new String[] {
+			   "documentation", "Effective cloud cover: 0..100% (Neff)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_CloudCoverHigh(),
+		   source,
+		   new String[] {
+			   "documentation", "High cloud cover (>7 km): 0..100% (Nh)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_CloudCoverMid(),
+		   source,
+		   new String[] {
+			   "documentation", "Midlevel cloud cover (2-7 km): 0..100% (Nm)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_CloudCoverLow(),
+		   source,
+		   new String[] {
+			   "documentation", "Low cloud cover (lower than 2 km): 0..100% (Nl)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_IrRadianceGlobal(),
+		   source,
+		   new String[] {
+			   "documentation", "Global Irradiance: kJ/m2 (Rad1h)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_SurfacePressure(),
+		   source,
+		   new String[] {
+			   "documentation", "Surface pressure, reduced: Pa (PPPP)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_PrecipitationLarger02Last6(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability of precipitation > 0.2mm during the last 6 hours: 0..100% (R602)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_PrecipitationLarger50Last6(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability of precipitation > 5mm during the last 6 hours: 0..100% (R650)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_PrecipitationLarger02LastDay(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability of precipitation > 0.2mm during the last 24 hours: 0..100% (Rd02)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_PrecipitationLarger50LastDay(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability of precipitation > 5mm during the last 24 hours: 0..100% (Rd50)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_PrecipitationLarger00Last12(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability of precipitation > 0.0mm during the last 12 hours: 0..100% (Rh00)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_PrecipitationLarger02Last12(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability of precipitation > 0.2mm during the last 12 hours: 0..100% (Rh02)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_PrecipitationLarger10Last12(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability of precipitation > 1 mm during the last 12 hours: 0..100% (Rh10)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_PrecipitationLarger50Last12(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability of precipitation > 5mm during the last 12 hours: 0..100% (Rh50)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_PrecipitationSignificantWeatherTotal(),
+		   source,
+		   new String[] {
+			   "documentation", "Total precipitation during the last hour consistent with significant weather: kg/m2 (RR1c)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_PrecipitationSignificantWeatherLast3(),
+		   source,
+		   new String[] {
+			   "documentation", "Total precipitation during the last 3 hours  consistent with significant weather: kg/m2 (RR3c)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_SnowRainEqLast1(),
+		   source,
+		   new String[] {
+			   "documentation", "Snow-Rain-Equivalent during the last hour: kg/m2 (RRS1c)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_SnowRainEqLast3(),
+		   source,
+		   new String[] {
+			   "documentation", "Snow-Rain-Equivalent during the 3 hours: kg/m2 (RRS3c)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_SunshineDurationLast1(),
+		   source,
+		   new String[] {
+			   "documentation", "Sunshine duration during the last Hour: s (SunD1)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_TempAboveSurface5(),
+		   source,
+		   new String[] {
+			   "documentation", "Temperature 5cm above surface: Kelvin (T5cm)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_TempAboveSurface200(),
+		   source,
+		   new String[] {
+			   "documentation", "Temperature 2m above surface: Kelvin (TTT)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_TempDewpointAboveSurface200(),
+		   source,
+		   new String[] {
+			   "documentation", "Dewpoint 2m above surface: Kelvin (Td)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_TempMinLast12(),
+		   source,
+		   new String[] {
+			   "documentation", "Minimum temperature - within the last 12 hours: Kelvin (TN)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_TempMaxLast12(),
+		   source,
+		   new String[] {
+			   "documentation", "Maximum temperature - within the last 12 hours: Kelvin (TX)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_Visibility(),
+		   source,
+		   new String[] {
+			   "documentation", "Visibility: m (VV)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_PastWeather(),
+		   source,
+		   new String[] {
+			   "documentation", "Past weather during the last 6 hours: - (W1W2)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_SignificantWeather(),
+		   source,
+		   new String[] {
+			   "documentation", "Significant Weather: - (ww)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_FogPropLast1(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability for fog within the last hour: 0..100% (wwM)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_FogPropLast6(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability for fog within the last 6 hours: 0..100% (wwM6)"
+		   });
+		addAnnotation
+		  (getMOSMIXSWeatherReport_FogPropLast12(),
+		   source,
+		   new String[] {
+			   "documentation", "Probability for fog within the last 12 hours: 0..100% (wwMh)"
+		   });
+		addAnnotation
+		  (astrotimeEClass,
+		   source,
+		   new String[] {
+			   "documentation", "Additional astro time information, like sunset und sunrise times  for a certain day"
+		   });
+		addAnnotation
+		  (getAstrotime_SunsetTwilight(),
+		   source,
+		   new String[] {
+			   "documentation", "Times for the civil twilight, means 6 degrees below the horizon"
+		   });
+		addAnnotation
+		  (getAstrotime_SunriseTwilight(),
+		   source,
+		   new String[] {
+			   "documentation", "Times for the civil twilight, means 6 degrees below the horizon"
+		   });
+		addAnnotation
+		  (getWeatherStation_Id(),
+		   source,
+		   new String[] {
+			   "documentation", "The DWD id"
+		   });
+		addAnnotation
+		  (getWeatherStation_IcaoCode(),
+		   source,
+		   new String[] {
+			   "documentation", "Internation Civil Aviation Organization code"
+		   });
 	}
 
 } //WeatherPackageImpl


### PR DESCRIPTION
These are the changes I have made in order to integrate the weather project into sensinact:
+ I changed the `suppressGenModelAnnotation` in the weather model to `false` because I am using the documentation annotation to set up some metadata in sensinact;
+ I made the `WeatherReportIndex/Search` services optionally configurable. This allows me to specify the `WeatherReportHandler` to inject, so that I can use the sesinact custom handler in sensincat to push updates while indexing a report.
+ I updated the documentation (the commands in the examples were not properly spelled), but nothing too fancy here