### PR TITLE
significant weather adjustments and documentation

### DIFF
--- a/org.gecko.weather.api/src/org/gecko/weather/api/util/DWDUtils.java
+++ b/org.gecko.weather.api/src/org/gecko/weather/api/util/DWDUtils.java
@@ -27,8 +27,11 @@ import java.util.zip.ZipInputStream;
 
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.gecko.weather.model.weather.MOSMIXSWeatherReport;
 import org.gecko.weather.model.weather.Measurement;
+import org.gecko.weather.model.weather.W1W2;
+import org.gecko.weather.model.weather.WMOWeatherCodeType;
 import org.gecko.weather.model.weather.WeatherFactory;
 import org.gecko.weather.model.weather.WeatherPackage;
 
@@ -433,176 +436,163 @@ public class DWDUtils {
 		if (isNull(value) || "-".equals(value.toString().trim())) {
 			return;
 		}
-		EAttribute attr;
-//		Object castedValue = value;
+		EStructuralFeature feature;
 		switch (measurementId) {
 		case "DD":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_DIRECTION;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_DIRECTION;
 			break;
 		case "PPPP":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SURFACE_PRESSURE;
-			// Double.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SURFACE_PRESSURE;
 			break;
 		case "TX":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__TEMP_MAX_LAST12;
-			// castedValue = Double.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__TEMP_MAX_LAST12;
 			break;
 		case "TTT":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__TEMP_ABOVE_SURFACE200;
-			// castedValue = value;//castedValue = Double.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__TEMP_ABOVE_SURFACE200;
 			break;
 		case "Td":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__TEMP_DEWPOINT_ABOVE_SURFACE200;
-//			castedValue = value;//castedValue = Double.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__TEMP_DEWPOINT_ABOVE_SURFACE200;
 			break;
 		case "TN":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__TEMP_MIN_LAST12;
-//			castedValue = Double.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__TEMP_MIN_LAST12;
 			break;
 		case "T5cm":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__TEMP_ABOVE_SURFACE5;
-			// castedValue = Double.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__TEMP_ABOVE_SURFACE5;
 			break;
 		case "FF":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_SPEED;
-			// castedValue = Float.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_SPEED;
 			break;
 		case "FX1":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_GUST_LAST_HOUR;
-			// castedValue = Float.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_GUST_LAST_HOUR;
 			break;
 		case "FX3":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_GUST_LAST_THREE_HOURS;
-			// castedValue = Float.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_GUST_LAST_THREE_HOURS;
 			break;
 		case "FXh":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_GUST_MAX_LAST12_HOURS;
-			// castedValue = Float.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_GUST_MAX_LAST12_HOURS;
 			break;
 		case "FXh25":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_GUST_PROB25;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_GUST_PROB25;
 			break;
 		case "FXh40":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_GUST_PROB40;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_GUST_PROB40;
 			break;
 		case "FXh55":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_GUST_PROB55;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__WIND_GUST_PROB55;
 			break;
 		case "N":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__CLOUD_COVER_TOTAL;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__CLOUD_COVER_TOTAL;
 			break;
 		case "Neff":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__CLOUD_COVER_EFFECTIVE;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__CLOUD_COVER_EFFECTIVE;
 			break;
 		case "Nh":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__CLOUD_COVER_HIGH;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__CLOUD_COVER_HIGH;
 			break;
 		case "Nm":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__CLOUD_COVER_MID;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__CLOUD_COVER_MID;
 			break;
 		case "Nl":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__CLOUD_COVER_LOW;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__CLOUD_COVER_LOW;
 			break;
 		case "N05":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__CLOUD_COVER_BELOW500;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__CLOUD_COVER_BELOW500;
 			break;
 		case "VV":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__VISIBILITY;
-			// castedValue = Integer.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__VISIBILITY;
 			break;
 		case "wwM":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST1;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST1;
 			break;
 		case "wwM6":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST6;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST6;
 			break;
 		case "wwMh":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST12;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST12;
 			break;
 		case "ww":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER;
-			// castedValue = Integer.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER3_HOURS;
+			int wwCode = Math.round((float) value);  // e.g., 1.0 → 1
+			String wwEnumKey = WMOWeatherCodeType.WUNKNOWN.getLiteral();
+			if(wwCode >= 0 && wwCode <= 99) {
+				wwEnumKey = String.format("%02d", wwCode); // → "01"
+			}
+			WMOWeatherCodeType wwEnumCode = WMOWeatherCodeType.get(wwEnumKey);
+			if(wwEnumCode == null) wwEnumCode = WMOWeatherCodeType.WUNKNOWN;
+			value = wwEnumCode;
 			break;
 		case "W1W2":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PAST_WEATHER;
-			// castedValue = Integer.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS;
+			int code = Math.round((float) value); // e.g. → 30.0 -> 30
+			String padded = String.format("%04d", code); //e.g 30 -> "0030"
+			String w1Str = padded.substring(0, 2);
+			String w2Str = padded.substring(2, 4); 
+			WMOWeatherCodeType w1Code = WMOWeatherCodeType.get(w1Str);
+			if(w1Code == null) {
+				w1Code = WMOWeatherCodeType.WUNKNOWN;
+			}
+			WMOWeatherCodeType w2Code = WMOWeatherCodeType.get(w2Str);
+			if(w2Code == null) {
+				w2Code = WMOWeatherCodeType.WUNKNOWN;
+			}
+			W1W2 w1w2 = WeatherFactory.eINSTANCE.createW1W2();
+			w1w2.setW1(w1Code);
+			w1w2.setW2(w2Code);
+			value = w1w2;
 			break;
 		case "RR1c":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_SIGNIFICANT_WEATHER_TOTAL;
-			// castedValue = Double.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_SIGNIFICANT_WEATHER_TOTAL;
 			break;
 		case "RRS1c":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SNOW_RAIN_EQ_LAST1;
-			// castedValue = Double.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SNOW_RAIN_EQ_LAST1;
 			break;
 		case "RR3c":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_SIGNIFICANT_WEATHER_LAST3;
-			// castedValue = Double.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_SIGNIFICANT_WEATHER_LAST3;
 			break;
 		case "RRS3c":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SNOW_RAIN_EQ_LAST3;
-			// castedValue = Double.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SNOW_RAIN_EQ_LAST3;
 			break;
 		case "R602":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER02_LAST6;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER02_LAST6;
 			break;
 		case "R650":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER50_LAST6;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER50_LAST6;
 			break;
 		case "Rh00":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER00_LAST12;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER00_LAST12;
 			break;
 		case "Rh02":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER02_LAST12;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER02_LAST12;
 			break;
 		case "Rh10":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER10_LAST12;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER10_LAST12;
 			break;
 		case "Rh50":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER50_LAST12;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER50_LAST12;
 			break;
 		case "Rd02":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER02_LAST_DAY;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER02_LAST_DAY;
 			break;
 		case "Rd50":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER50_LAST_DAY;
-			// castedValue = Short.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__PRECIPITATION_LARGER50_LAST_DAY;
 			break;
 		case "Rad1h":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__IR_RADIANCE_GLOBAL;
-			// castedValue = Double.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__IR_RADIANCE_GLOBAL;
 			break;
 		case "SunD1":
-			attr = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SUNSHINE_DURATION_LAST1;
-			// castedValue = Integer.valueOf(value.toString());
+			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SUNSHINE_DURATION_LAST1;
 			break;
 		default:
 			return;
-//			throw new IllegalArgumentException("Unexpected value: " + measurementId);
 		}
-		if (nonNull(attr) && value.getClass() == attr.getEAttributeType().getInstanceClass()) {
-			report.eSet(attr, value);
+		if(nonNull(feature)) {
+			if(feature instanceof EAttribute attr) {
+				if(value.getClass() == attr.getEAttributeType().getInstanceClass()) {
+					report.eSet(attr, value);			
+				}
+			} else {
+				report.eSet(feature, value);		
+			}
 		}
-
 	}
 }

--- a/org.gecko.weather.api/src/org/gecko/weather/api/util/DWDUtils.java
+++ b/org.gecko.weather.api/src/org/gecko/weather/api/util/DWDUtils.java
@@ -513,25 +513,19 @@ public class DWDUtils {
 		case "ww":
 			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER3_HOURS;
 			int wwCode = Math.round((float) value);  // e.g., 1.0 → 1
-			String wwEnumKey = WMOWeatherCodeType.WUNKNOWN.getLiteral();
-			if(wwCode >= 0 && wwCode <= 99) {
-				wwEnumKey = String.format("%02d", wwCode); // → "01"
-			}
-			WMOWeatherCodeType wwEnumCode = WMOWeatherCodeType.get(wwEnumKey);
+			WMOWeatherCodeType wwEnumCode = WMOWeatherCodeType.get(wwCode);
 			if(wwEnumCode == null) wwEnumCode = WMOWeatherCodeType.WUNKNOWN;
 			value = wwEnumCode;
 			break;
 		case "W1W2":
 			feature = WeatherPackage.Literals.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS;
 			int code = Math.round((float) value); // e.g. → 30.0 -> 30
-			String padded = String.format("%04d", code); //e.g 30 -> "0030"
-			String w1Str = padded.substring(0, 2);
-			String w2Str = padded.substring(2, 4); 
-			WMOWeatherCodeType w1Code = WMOWeatherCodeType.get(w1Str);
+			int[] w1w2Code = parse(code);
+			WMOWeatherCodeType w1Code = WMOWeatherCodeType.get(w1w2Code[0]);
 			if(w1Code == null) {
 				w1Code = WMOWeatherCodeType.WUNKNOWN;
 			}
-			WMOWeatherCodeType w2Code = WMOWeatherCodeType.get(w2Str);
+			WMOWeatherCodeType w2Code = WMOWeatherCodeType.get(w1w2Code[1]);
 			if(w2Code == null) {
 				w2Code = WMOWeatherCodeType.WUNKNOWN;
 			}
@@ -595,4 +589,11 @@ public class DWDUtils {
 			}
 		}
 	}
+	
+	public static int[] parse(int number) {
+        // This works for any non-negative integer (e.g., 3, 23, 123, 1234)
+        int firstValue = number / 100;
+        int secondValue = number % 100;
+        return new int[] {firstValue, secondValue};
+    }
 }

--- a/org.gecko.weather.dwd.forecast/README.MD
+++ b/org.gecko.weather.dwd.forecast/README.MD
@@ -14,9 +14,9 @@ The `org.gecko.weathcer.dwd.fc.impl.DWDMOSMIXStationForecastFetcher#onDecoded` c
 
 ## Commands
 
-### Start loading weatherdata
+### Start loading weather data
 
-Gogo Command: *forecastbystation*
+Gogo Command: *forecastByStation*
 
 **Parameter:** 
 
@@ -26,11 +26,11 @@ Gogo Command: *forecastbystation*
 
 Start loading weather data for station with id *“10567”*
 
-`g! forecastbystation 10567` 
+`g! forecastByStation 10567` 
 
 ### Stop cron jop by Station
 
-Gogo Command: *forecaststop*
+Gogo Command: *forecastStop*
 
 **Parameter: **
 
@@ -38,7 +38,7 @@ Gogo Command: *forecaststop*
 
 **Example:**
 
-Stop updating weatcher reports for station with id *“10567”*: 
+Stop updating weather reports for station with id *“10567”*: 
 
-`g! forecaststop 10567` 
+`g! forecastStop 10567` 
 

--- a/org.gecko.weather.dwd.forecast/src/org/gecko/weather/dwd/fc/impl/DWDMOSMIXStationForecastFetcher.java
+++ b/org.gecko.weather.dwd.forecast/src/org/gecko/weather/dwd/fc/impl/DWDMOSMIXStationForecastFetcher.java
@@ -41,6 +41,7 @@ import org.gecko.weather.model.weather.Astrotime;
 import org.gecko.weather.model.weather.GeoPosition;
 import org.gecko.weather.model.weather.MOSMIXSWeatherReport;
 import org.gecko.weather.model.weather.Station;
+import org.gecko.weather.model.weather.W1W2;
 import org.gecko.weather.model.weather.WeatherFactory;
 import org.gecko.weather.model.weather.WeatherStation;
 import org.osgi.service.component.annotations.Activate;
@@ -158,7 +159,7 @@ public class DWDMOSMIXStationForecastFetcher extends DWDEMFFetcher<KmlType> impl
 	public void doDecode(KmlType kml) {
 		MOSMIXSWeatherReport[] reports = null;
 
-		LOGGER.log(Level.DEBUG, "[{0}] Decoding the MOSMIX KML data for station {1}", getName(), station.getName());
+		LOGGER.log(Level.DEBUG, "[{0}] Decoding the MOSMIX KML data for station {1}", getName(), station == null ? "NONE" : station.getName());
 		DocumentType documentType = (DocumentType) kml.getAbstractFeatureGroupGroup()
 				.get(kmlPackage.getDocumentRoot_Document(), true);
 		FeatureEList<PlacemarkType> placemarkTypeList = (FeatureEList<PlacemarkType>) documentType
@@ -232,6 +233,10 @@ public class DWDMOSMIXStationForecastFetcher extends DWDEMFFetcher<KmlType> impl
 		}
 		for (int i = 0; i < reports.length; i++) {
 			MOSMIXSWeatherReport r = reports[i];
+			if(r.getSignificantWeather6Hours() == null) {
+				W1W2 w1w2 = WeatherFactory.eINSTANCE.createW1W2();
+				r.setSignificantWeather6Hours(w1w2);				
+			}
 			onDecoded(r);
 		}
 	}

--- a/org.gecko.weather.model/model/SignificantWeatherDocs.md
+++ b/org.gecko.weather.model/model/SignificantWeatherDocs.md
@@ -1,0 +1,196 @@
+# Note on DWD Significant Weather
+
+The **DWD (Deutscher Wetterdienst)** — Germany's national meteorological service — uses the term **"significant weather"** ("**signifikantes Wetter**" in German) to refer to **weather phenomena that are relevant for public safety, aviation, or meteorological analysis**, due to their intensity, impact, or deviation from normal conditions.
+
+### In DWD's context, "significant weather" typically includes:
+
+1. **Precipitation**:
+   - Rain (light to heavy)
+   - Snow
+   - Freezing rain
+   - Sleet or hail
+2. **Storm-related phenomena**:
+   - Thunderstorms
+   - Lightning
+   - Wind gusts (especially when severe or damaging)
+3. **Reduced visibility**:
+   - Fog
+   - Heavy rain or snow reducing visibility
+4. **Other impactful events**:
+   - Sand or dust storms
+   - Volcanic ash (rare in Germany but relevant for aviation)
+
+###  **"Significant weather" in MOSMIX is a categorical value**, **not a probability**.
+
+It’s a **forecasted weather condition**, represented by a **numerical code**, describing the **most dominant expected weather phenomenon** at a given time and location.
+
+The **`ww` parameter** (WMO code for present weather) in MOSMIX is used to represent **significant weather conditions**, 
+
+Here’s a complete table of **WMO Table 4678** significant weather codes—the exact values that the `ww` parameter in MOSMIX can take. These cover all phenomena from 0 to 99 used in present and forecast weather:
+
+| Code | Description                               |
+| ---- | ----------------------------------------- |
+| 00   | No significant weather                    |
+| 04   | Haze/smoke/dust, V ≥ 1 km                 |
+| 05   | Haze/smoke/dust, V < 1 km                 |
+| 10   | Mist                                      |
+| 20   | Fog                                       |
+| 21   | Precipitation (recent, unspecified)       |
+| 22   | Drizzle or snow grains (recent)           |
+| 23   | Rain (recent)                             |
+| 24   | Snow (recent)                             |
+| 25   | Freezing rain/drizzle (recent)            |
+| 26   | Thunderstorm (recent)                     |
+| 27   | Blowing snow or sand (recent)             |
+| 28   | Blowing snow/sand, V ≥ 1 km (recent)      |
+| 29   | Blowing snow/sand, V < 1 km (recent)      |
+| 30   | Fog                                       |
+| 31   | Patches of fog                            |
+| 32   | Fog — thinning                            |
+| 33   | Fog — no change                           |
+| 34   | Fog — thickening                          |
+| 35   | Rime fog                                  |
+| 40   | Precipitation (present, unspecified)      |
+| 41   | Precipitation slight/moderate             |
+| 42   | Precipitation heavy                       |
+| 43   | Liquid precipitation slight/mod           |
+| 44   | Liquid precipitation heavy                |
+| 45   | Solid precipitation slight/mod            |
+| 50   | Drizzle                                   |
+| 51   | Drizzle slight                            |
+| 52   | Drizzle moderate                          |
+| 53   | Drizzle heavy                             |
+| 54   | Freezing drizzle slight                   |
+| 55   | Freezing drizzle moderate                 |
+| 56   | Freezing drizzle heavy                    |
+| 57   | Drizzle & rain slight                     |
+| 58   | Drizzle & rain mod/heavy                  |
+| 60   | Rain                                      |
+| 61   | Rain slight                               |
+| 62   | Rain moderate                             |
+| 63   | Rain heavy                                |
+| 64   | Freezing rain slight                      |
+| 65   | Freezing rain moderate                    |
+| 66   | Freezing rain heavy                       |
+| 67   | Rain + snow (or drizzle) slight           |
+| 68   | Rain + snow mod/heavy                     |
+| 70   | Snow                                      |
+| 71   | Snow slight                               |
+| 72   | Snow moderate                             |
+| 73   | Snow heavy                                |
+| 74   | Ice pellets slight                        |
+| 75   | Ice pellets moderate                      |
+| 76   | Ice pellets heavy                         |
+| 77   | Snow grains                               |
+| 80   | Showers                                   |
+| 81   | Rain showers slight                       |
+| 82   | Rain showers moderate                     |
+| 83   | Rain showers heavy                        |
+| 85   | Snow showers slight                       |
+| 86   | Snow showers moderate                     |
+| 87   | Snow showers heavy                        |
+| 90   | Hail showers (no thunder)                 |
+| 91   | Thunderstorm recent + slight rain         |
+| 92   | Thunderstorm recent + mod/heavy rain      |
+| 93   | Thunderstorm recent + slight snow/hail    |
+| 94   | Thunderstorm recent + mod/heavy snow/hail |
+| 95   | Thunderstorm slight/moderate, no hail     |
+| 96   | Thunderstorm with slight hail             |
+| 97   | Thunderstorm heavy, no hail               |
+| 98   | Thunderstorm with dust/sand storm         |
+| 99   | Thunderstorm heavy with hail              |
+
+### 🔄 What codes 00–03 actually mean in MOSMIX:
+
+These are used **exclusively** for cloudiness behavior over the forecast period:
+
+| Code | Description                               |
+| ---- | ----------------------------------------- |
+| 00   | No change in cloud cover (no development) |
+| 01   | Cloudiness is **decreasing**              |
+| 02   | Cloudiness remains **unchanged**          |
+| 03   | Cloudiness is **increasing**              |
+
+### 🧩 So here's the key difference:
+
+- **00–03**: MOSMIX-only codes for **cloud trend**, *not* part of WMO's present-weather system.
+- **04–99**: Standard **WMO Table 4678** significant weather codes used by `ww` in MOSMIX.
+
+------
+
+### ✅ Final Summary for `ww`
+
+- Valid values: **00–03** for cloud cover trend (MOSMIX-specific).
+- Plus **04–99**, matching WMO weather codes (rain, snow, hail, fog, etc.).
+- Always treat `ww` as the **union** of these two sets when parsing MOSMIX data.
+
+## W1W2
+
+**`w1w2` refers to the past 6 hours**, which is consistent with the MOSMIX reports where:
+
+- `w1w2` encodes **significant weather for two consecutive 3-hour intervals in the past 6 hours**.
+- Each **two-digit code** corresponds to one 3-hour block.
+
+### Summary for `w1w2`:
+
+| Part | Time Interval          | Code type                    |
+| ---- | ---------------------- | ---------------------------- |
+| `w1` | Past 6 to past 3 hours | WMO significant weather code |
+| `w2` | Past 3 to current hour | WMO significant weather code |
+
+### Example:
+
+`w1w2 = "0103"` means:
+
+- `01` = significant weather code for 6-3 hours ago
+- `03` = significant weather code for 3-0 hours ago
+
+So, looking at the definition, **ww** should be basically be the same as the **w2** part of **w1w2**. However, **in DWD MOSMIX forecasts**, you might **receive different values for `ww` and `w2` (the second part of `w1w2`) for the same forecast time**.
+
+------
+
+### 🔍 So why do `ww` and `w2` sometimes differ?
+
+Even though both describe **significant weather in the 3 hours before the forecast time**, they are **not always derived using the exact same algorithm**. Here's why:
+
+------
+
+### 🔄 1. **`ww` is a direct forecast parameter**
+
+- `ww` is **forecasted directly** by the MOSMIX statistical model for the specific 3-hour interval before the time step.
+- It’s derived using a **probabilistic model ensemble** that fuses NWP (numerical weather prediction) outputs.
+- The model may apply **thresholds, weights, or filters** to highlight **the most relevant or expected** weather condition.
+
+------
+
+### 🔢 2. **`w1w2` is post-processed from hourly weather values**
+
+- `w1w2` may be **computed** from **hourly or sub-hourly weather symbols** (like from `ww1`, `ww2`, etc.).
+- DWD documentation suggests that `w1w2` can be assembled using **dominant or most frequent** codes in the 3-hour blocks.
+
+Thus, `w2` might:
+
+- Reflect a **mode** or **aggregated condition**,
+- Or be based on a slightly different **threshold logic** (e.g., occurrence vs dominance).
+
+------
+
+### 📌 Example of divergence
+
+Let’s say:
+
+- 3 hours before the forecast time, conditions vary:
+  - 08:00–09:00: rain (`ww=61`)
+  - 09:00–10:00: no weather (`ww=00`)
+  - 10:00–11:00: drizzle (`ww=51`)
+- The **`w2` code** (computed from the block) might be `51` (drizzle),
+- But the **`ww` forecast** might select `61` (rain) as **more impactful**, depending on model output.
+
+------
+
+### ✅ In short:
+
+| Parameter | Purpose                                | How it's determined                       |
+| --------- | -------------------------------------- | ----------------------------------------- |
+| `ww`      | Forecasted most significant weather    | Direct model output (3-hourly)            |
+| `w2`      | Aggregated code for last 3-hour period | Derived from hourly/post-processed values |

--- a/org.gecko.weather.model/model/dwd-weather.ecore
+++ b/org.gecko.weather.model/model/dwd-weather.ecore
@@ -269,14 +269,16 @@
         <details key="documentation" value="Visibility: m (VV)"/>
       </eAnnotations>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="pastWeather" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EFloatObject">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="significantWeather6Hours"
+        eType="#//W1W2" containment="true">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="documentation" value="Past weather during the last 6 hours: - (W1W2)"/>
+        <details key="documentation" value="Significant weather during the last 6 hours. It encodes significant weather for two consecutive 3-hour intervals in the past 6 hours: - (W1W2)"/>
       </eAnnotations>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="significantWeather" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EFloatObject">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="significantWeather3Hours"
+        eType="#//WMOWeatherCodeType" defaultValueLiteral="UNKNOWN">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="documentation" value="Significant Weather: - (ww)"/>
+        <details key="documentation" value="Significant weather during the past 3 hours: - (ww)"/>
       </eAnnotations>
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="fogPropLast1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EFloatObject">
@@ -326,6 +328,387 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="icaoCode" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="Internation Civil Aviation Organization code"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="WMOWeatherCodeType">
+    <eLiterals name="W_00" literal="00">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="No change in cloud cover (MOSMIX-specific)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_01" value="1" literal="01">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Cloudiness is decreasing (MOSMIX-specific)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_02" value="2" literal="02">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Cloudiness remains unchanged (MOSMIX-specific)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_03" value="3" literal="03">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Cloudiness is increasing (MOSMIX-specific)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_04" value="4" literal="04">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Haze, smoke, dust, visibility ≥ 1 km"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_05" value="5" literal="05">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Haze, smoke, dust, visibility &lt; 1 km"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_10" value="10" literal="10">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Mist"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_20" value="20" literal="20">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Fog"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_21" value="21" literal="21">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Precipitation (recent, unspecified)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_22" value="22" literal="22">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Drizzle or snow grains (recent)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_23" value="23" literal="23">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Rain (recent)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_24" value="24" literal="24">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Snow (recent)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_25" value="25" literal="25">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Freezing rain/drizzle (recent)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_26" value="26" literal="26">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Thunderstorm (recent)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_27" value="27" literal="27">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Blowing snow or sand (recent)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_28" value="28" literal="28">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Blowing snow/sand, V ≥ 1 km (recent)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_29" value="29" literal="29">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Blowing snow/sand, V &lt; 1 km (recent)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_30" value="30" literal="30">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Fog"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_31" value="31" literal="31">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Patches of fog"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_32" value="32" literal="32">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Fog — thinning"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_33" value="33" literal="33">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Fog — no change"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_34" value="34" literal="34">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Fog — thickening"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_35" value="35" literal="35">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Rime fog"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_40" value="40" literal="40">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Precipitation (present, unspecified)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_41" value="41" literal="41">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Precipitation slight/moderate"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_42" value="42" literal="42">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Precipitation heavy"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_43" value="43" literal="43">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Liquid precipitation slight/mod"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_44" value="44" literal="44">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Liquid precipitation heavy"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_45" value="45" literal="45">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Solid precipitation slight/mod"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_50" value="50" literal="50">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Drizzle"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_51" value="51" literal="51">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Drizzle slight"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_52" value="52" literal="52">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Drizzle moderate"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_53" value="53" literal="53">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Drizzle heavy"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_54" value="54" literal="54">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Freezing drizzle slight"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_55" value="55" literal="55">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Freezing drizzle moderate"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_56" value="56" literal="56">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Freezing drizzle heavy"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_57" value="57" literal="57">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Drizzle &amp; rain slight"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_58" value="58" literal="58">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Drizzle &amp; rain mod/heavy"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_60" value="60" literal="60">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Rain"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_61" value="61" literal="61">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Rain slight"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_62" value="62" literal="62">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Rain moderate"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_63" value="63" literal="63">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Rain heavy"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_64" value="64" literal="64">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Freezing rain slight"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_65" value="65" literal="65">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Freezing rain moderate"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_66" value="66" literal="66">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Freezing rain heavy"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_67" value="67" literal="67">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Rain + snow (or drizzle) slight"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_68" value="68" literal="68">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Rain + snow mod/heavy"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_70" value="70" literal="70">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Snow"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_71" value="71" literal="71">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Snow slight"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_72" value="72" literal="72">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Snow moderate"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_73" value="73" literal="73">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Snow heavy"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_74" value="74" literal="74">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Ice pellets slight"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_75" value="75" literal="75">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Ice pellets moderate"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_76" value="76" literal="76">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Ice pellets heavy"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_77" value="77" literal="77">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Snow grains"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_80" value="80" literal="80">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Showers"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_81" value="81" literal="81">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Rain showers slight"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_82" value="82" literal="82">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Rain showers moderate"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_83" value="83" literal="83">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Rain showers heavy"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_85" value="85" literal="85">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Snow showers slight"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_86" value="86" literal="86">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Snow showers moderate"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_87" value="87" literal="87">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Snow showers heavy"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_90" value="90" literal="90">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Hail showers (no thunder)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_91" value="91" literal="91">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Thunderstorm recent + slight rain"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_92" value="92" literal="92">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Thunderstorm recent + mod/heavy rain"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_93" value="93" literal="93">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Thunderstorm recent + slight snow/hail"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_94" value="94" literal="94">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Thunderstorm recent + mod/heavy snow/hail"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_95" value="95" literal="95">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Thunderstorm, no hail (slight or moderate)"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_96" value="96" literal="96">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Thunderstorm with slight hail"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_97" value="97" literal="97">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Thunderstorm, heavy, no hail"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_98" value="98" literal="98">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Thunderstorm with dust or sandstorm"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_99" value="99" literal="99">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Thunderstorm with heavy hail"/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="W_UNKNOWN" value="1000" literal="UNKNOWN">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="No value was set"/>
+      </eAnnotations>
+    </eLiterals>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="W1W2">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="w1" eType="#//WMOWeatherCodeType"
+        defaultValueLiteral="UNKNOWN">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Significant weather in the past 6 to 3 hours: - (W1 part of W1W2)"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="w2" eType="#//WMOWeatherCodeType"
+        defaultValueLiteral="UNKNOWN">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Significant weather in the past 3 hours: - (W2 part of W1W2)"/>
       </eAnnotations>
     </eStructuralFeatures>
   </eClassifiers>

--- a/org.gecko.weather.model/model/dwd-weather.genmodel
+++ b/org.gecko.weather.model/model/dwd-weather.genmodel
@@ -8,6 +8,81 @@
   <foreignModel>dwd-weather.ecore</foreignModel>
   <genPackages prefix="Weather" basePackage="org.gecko.weather.model" resource="XMI"
       disposableProviderFactory="true" ecorePackage="dwd-weather.ecore#/">
+    <genEnums typeSafeEnumCompatible="false" ecoreEnum="dwd-weather.ecore#//WMOWeatherCodeType">
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_00"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_01"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_02"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_03"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_04"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_05"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_10"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_20"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_21"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_22"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_23"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_24"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_25"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_26"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_27"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_28"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_29"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_30"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_31"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_32"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_33"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_34"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_35"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_40"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_41"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_42"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_43"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_44"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_45"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_50"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_51"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_52"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_53"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_54"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_55"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_56"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_57"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_58"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_60"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_61"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_62"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_63"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_64"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_65"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_66"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_67"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_68"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_70"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_71"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_72"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_73"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_74"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_75"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_76"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_77"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_80"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_81"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_82"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_83"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_85"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_86"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_87"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_90"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_91"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_92"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_93"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_94"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_95"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_96"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_97"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_98"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_99"/>
+      <genEnumLiterals ecoreEnumLiteral="dwd-weather.ecore#//WMOWeatherCodeType/W_UNKNOWN"/>
+    </genEnums>
     <genClasses ecoreClass="dwd-weather.ecore#//Station">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//Station/name"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference dwd-weather.ecore#//Station/location"/>
@@ -90,8 +165,8 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//MOSMIXSWeatherReport/tempMinLast12"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//MOSMIXSWeatherReport/tempMaxLast12"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//MOSMIXSWeatherReport/visibility"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//MOSMIXSWeatherReport/pastWeather"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//MOSMIXSWeatherReport/significantWeather"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference dwd-weather.ecore#//MOSMIXSWeatherReport/significantWeather6Hours"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//MOSMIXSWeatherReport/significantWeather3Hours"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//MOSMIXSWeatherReport/fogPropLast1"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//MOSMIXSWeatherReport/fogPropLast6"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//MOSMIXSWeatherReport/fogPropLast12"/>
@@ -108,6 +183,10 @@
     <genClasses ecoreClass="dwd-weather.ecore#//WeatherStation">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//WeatherStation/id"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//WeatherStation/icaoCode"/>
+    </genClasses>
+    <genClasses ecoreClass="dwd-weather.ecore#//W1W2">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//W1W2/w1"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//W1W2/w2"/>
     </genClasses>
   </genPackages>
 </genmodel:GenModel>

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/MOSMIXSWeatherReport.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/MOSMIXSWeatherReport.java
@@ -59,8 +59,8 @@ import org.osgi.annotation.versioning.ProviderType;
  *   <li>{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getTempMinLast12 <em>Temp Min Last12</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getTempMaxLast12 <em>Temp Max Last12</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getVisibility <em>Visibility</em>}</li>
- *   <li>{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getPastWeather <em>Past Weather</em>}</li>
- *   <li>{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getSignificantWeather <em>Significant Weather</em>}</li>
+ *   <li>{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getSignificantWeather6Hours <em>Significant Weather6 Hours</em>}</li>
+ *   <li>{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getSignificantWeather3Hours <em>Significant Weather3 Hours</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getFogPropLast1 <em>Fog Prop Last1</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getFogPropLast6 <em>Fog Prop Last6</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getFogPropLast12 <em>Fog Prop Last12</em>}</li>
@@ -948,54 +948,58 @@ public interface MOSMIXSWeatherReport extends WeatherReport {
 	void setVisibility(Float value);
 
 	/**
-	 * Returns the value of the '<em><b>Past Weather</b></em>' attribute.
+	 * Returns the value of the '<em><b>Significant Weather6 Hours</b></em>' containment reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * <!-- begin-model-doc -->
-	 * Past weather during the last 6 hours: - (W1W2)
+	 * Significant weather during the last 6 hours. It encodes significant weather for two consecutive 3-hour intervals in the past 6 hours: - (W1W2)
 	 * <!-- end-model-doc -->
-	 * @return the value of the '<em>Past Weather</em>' attribute.
-	 * @see #setPastWeather(Float)
-	 * @see org.gecko.weather.model.weather.WeatherPackage#getMOSMIXSWeatherReport_PastWeather()
-	 * @model
+	 * @return the value of the '<em>Significant Weather6 Hours</em>' containment reference.
+	 * @see #setSignificantWeather6Hours(W1W2)
+	 * @see org.gecko.weather.model.weather.WeatherPackage#getMOSMIXSWeatherReport_SignificantWeather6Hours()
+	 * @model containment="true"
 	 * @generated
 	 */
-	Float getPastWeather();
+	W1W2 getSignificantWeather6Hours();
 
 	/**
-	 * Sets the value of the '{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getPastWeather <em>Past Weather</em>}' attribute.
+	 * Sets the value of the '{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getSignificantWeather6Hours <em>Significant Weather6 Hours</em>}' containment reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Past Weather</em>' attribute.
-	 * @see #getPastWeather()
+	 * @param value the new value of the '<em>Significant Weather6 Hours</em>' containment reference.
+	 * @see #getSignificantWeather6Hours()
 	 * @generated
 	 */
-	void setPastWeather(Float value);
+	void setSignificantWeather6Hours(W1W2 value);
 
 	/**
-	 * Returns the value of the '<em><b>Significant Weather</b></em>' attribute.
+	 * Returns the value of the '<em><b>Significant Weather3 Hours</b></em>' attribute.
+	 * The default value is <code>"UNKNOWN"</code>.
+	 * The literals are from the enumeration {@link org.gecko.weather.model.weather.WMOWeatherCodeType}.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * <!-- begin-model-doc -->
-	 * Significant Weather: - (ww)
+	 * Significant weather during the past 3 hours: - (ww)
 	 * <!-- end-model-doc -->
-	 * @return the value of the '<em>Significant Weather</em>' attribute.
-	 * @see #setSignificantWeather(Float)
-	 * @see org.gecko.weather.model.weather.WeatherPackage#getMOSMIXSWeatherReport_SignificantWeather()
-	 * @model
+	 * @return the value of the '<em>Significant Weather3 Hours</em>' attribute.
+	 * @see org.gecko.weather.model.weather.WMOWeatherCodeType
+	 * @see #setSignificantWeather3Hours(WMOWeatherCodeType)
+	 * @see org.gecko.weather.model.weather.WeatherPackage#getMOSMIXSWeatherReport_SignificantWeather3Hours()
+	 * @model default="UNKNOWN"
 	 * @generated
 	 */
-	Float getSignificantWeather();
+	WMOWeatherCodeType getSignificantWeather3Hours();
 
 	/**
-	 * Sets the value of the '{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getSignificantWeather <em>Significant Weather</em>}' attribute.
+	 * Sets the value of the '{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getSignificantWeather3Hours <em>Significant Weather3 Hours</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Significant Weather</em>' attribute.
-	 * @see #getSignificantWeather()
+	 * @param value the new value of the '<em>Significant Weather3 Hours</em>' attribute.
+	 * @see org.gecko.weather.model.weather.WMOWeatherCodeType
+	 * @see #getSignificantWeather3Hours()
 	 * @generated
 	 */
-	void setSignificantWeather(Float value);
+	void setSignificantWeather3Hours(WMOWeatherCodeType value);
 
 	/**
 	 * Returns the value of the '<em><b>Fog Prop Last1</b></em>' attribute.

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/W1W2.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/W1W2.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2012 - 2024 Data In Motion and others.
+ * All rights reserved. 
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *      Mark Hoffmann - initial API and implementation
+ */
+package org.gecko.weather.model.weather;
+
+import org.eclipse.emf.ecore.EObject;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>W1W2</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link org.gecko.weather.model.weather.W1W2#getW1 <em>W1</em>}</li>
+ *   <li>{@link org.gecko.weather.model.weather.W1W2#getW2 <em>W2</em>}</li>
+ * </ul>
+ *
+ * @see org.gecko.weather.model.weather.WeatherPackage#getW1W2()
+ * @model
+ * @generated
+ */
+@ProviderType
+public interface W1W2 extends EObject {
+	/**
+	 * Returns the value of the '<em><b>W1</b></em>' attribute.
+	 * The default value is <code>"UNKNOWN"</code>.
+	 * The literals are from the enumeration {@link org.gecko.weather.model.weather.WMOWeatherCodeType}.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Significant weather in the past 6 to 3 hours: - (W1 part of W1W2)
+	 * <!-- end-model-doc -->
+	 * @return the value of the '<em>W1</em>' attribute.
+	 * @see org.gecko.weather.model.weather.WMOWeatherCodeType
+	 * @see #setW1(WMOWeatherCodeType)
+	 * @see org.gecko.weather.model.weather.WeatherPackage#getW1W2_W1()
+	 * @model default="UNKNOWN"
+	 * @generated
+	 */
+	WMOWeatherCodeType getW1();
+
+	/**
+	 * Sets the value of the '{@link org.gecko.weather.model.weather.W1W2#getW1 <em>W1</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>W1</em>' attribute.
+	 * @see org.gecko.weather.model.weather.WMOWeatherCodeType
+	 * @see #getW1()
+	 * @generated
+	 */
+	void setW1(WMOWeatherCodeType value);
+
+	/**
+	 * Returns the value of the '<em><b>W2</b></em>' attribute.
+	 * The default value is <code>"UNKNOWN"</code>.
+	 * The literals are from the enumeration {@link org.gecko.weather.model.weather.WMOWeatherCodeType}.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Significant weather in the past 3 hours: - (W2 part of W1W2)
+	 * <!-- end-model-doc -->
+	 * @return the value of the '<em>W2</em>' attribute.
+	 * @see org.gecko.weather.model.weather.WMOWeatherCodeType
+	 * @see #setW2(WMOWeatherCodeType)
+	 * @see org.gecko.weather.model.weather.WeatherPackage#getW1W2_W2()
+	 * @model default="UNKNOWN"
+	 * @generated
+	 */
+	WMOWeatherCodeType getW2();
+
+	/**
+	 * Sets the value of the '{@link org.gecko.weather.model.weather.W1W2#getW2 <em>W2</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>W2</em>' attribute.
+	 * @see org.gecko.weather.model.weather.WMOWeatherCodeType
+	 * @see #getW2()
+	 * @generated
+	 */
+	void setW2(WMOWeatherCodeType value);
+
+} // W1W2

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/WMOWeatherCodeType.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/WMOWeatherCodeType.java
@@ -1,0 +1,2294 @@
+/*
+ * Copyright (c) 2012 - 2024 Data In Motion and others.
+ * All rights reserved. 
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *      Mark Hoffmann - initial API and implementation
+ */
+package org.gecko.weather.model.weather;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.emf.common.util.Enumerator;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the literals of the enumeration '<em><b>WMO Weather Code Type</b></em>',
+ * and utility methods for working with them.
+ * <!-- end-user-doc -->
+ * @see org.gecko.weather.model.weather.WeatherPackage#getWMOWeatherCodeType()
+ * @model
+ * @generated
+ */
+@ProviderType
+public enum WMOWeatherCodeType implements Enumerator {
+	/**
+	 * The '<em><b>W00</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * No change in cloud cover (MOSMIX-specific)
+	 * <!-- end-model-doc -->
+	 * @see #W00_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W00(0, "W_00", "00"),
+
+	/**
+	 * The '<em><b>W01</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Cloudiness is decreasing (MOSMIX-specific)
+	 * <!-- end-model-doc -->
+	 * @see #W01_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W01(1, "W_01", "01"),
+
+	/**
+	 * The '<em><b>W02</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Cloudiness remains unchanged (MOSMIX-specific)
+	 * <!-- end-model-doc -->
+	 * @see #W02_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W02(2, "W_02", "02"),
+
+	/**
+	 * The '<em><b>W03</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Cloudiness is increasing (MOSMIX-specific)
+	 * <!-- end-model-doc -->
+	 * @see #W03_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W03(3, "W_03", "03"),
+
+	/**
+	 * The '<em><b>W04</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Haze, smoke, dust, visibility ≥ 1 km
+	 * <!-- end-model-doc -->
+	 * @see #W04_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W04(4, "W_04", "04"),
+
+	/**
+	 * The '<em><b>W05</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Haze, smoke, dust, visibility < 1 km
+	 * <!-- end-model-doc -->
+	 * @see #W05_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W05(5, "W_05", "05"),
+
+	/**
+	 * The '<em><b>W10</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Mist
+	 * <!-- end-model-doc -->
+	 * @see #W10_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W10(10, "W_10", "10"),
+
+	/**
+	 * The '<em><b>W20</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Fog
+	 * <!-- end-model-doc -->
+	 * @see #W20_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W20(20, "W_20", "20"),
+
+	/**
+	 * The '<em><b>W21</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Precipitation (recent, unspecified)
+	 * <!-- end-model-doc -->
+	 * @see #W21_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W21(21, "W_21", "21"),
+
+	/**
+	 * The '<em><b>W22</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle or snow grains (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W22_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W22(22, "W_22", "22"),
+
+	/**
+	 * The '<em><b>W23</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W23_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W23(23, "W_23", "23"),
+
+	/**
+	 * The '<em><b>W24</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W24_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W24(24, "W_24", "24"),
+
+	/**
+	 * The '<em><b>W25</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing rain/drizzle (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W25_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W25(25, "W_25", "25"),
+
+	/**
+	 * The '<em><b>W26</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W26_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W26(26, "W_26", "26"),
+
+	/**
+	 * The '<em><b>W27</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Blowing snow or sand (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W27_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W27(27, "W_27", "27"),
+
+	/**
+	 * The '<em><b>W28</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Blowing snow/sand, V ≥ 1 km (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W28_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W28(28, "W_28", "28"),
+
+	/**
+	 * The '<em><b>W29</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Blowing snow/sand, V < 1 km (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W29_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W29(29, "W_29", "29"),
+
+	/**
+	 * The '<em><b>W30</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Fog
+	 * <!-- end-model-doc -->
+	 * @see #W30_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W30(30, "W_30", "30"),
+
+	/**
+	 * The '<em><b>W31</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Patches of fog
+	 * <!-- end-model-doc -->
+	 * @see #W31_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W31(31, "W_31", "31"),
+
+	/**
+	 * The '<em><b>W32</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Fog — thinning
+	 * <!-- end-model-doc -->
+	 * @see #W32_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W32(32, "W_32", "32"),
+
+	/**
+	 * The '<em><b>W33</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Fog — no change
+	 * <!-- end-model-doc -->
+	 * @see #W33_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W33(33, "W_33", "33"),
+
+	/**
+	 * The '<em><b>W34</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Fog — thickening
+	 * <!-- end-model-doc -->
+	 * @see #W34_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W34(34, "W_34", "34"),
+
+	/**
+	 * The '<em><b>W35</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rime fog
+	 * <!-- end-model-doc -->
+	 * @see #W35_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W35(35, "W_35", "35"),
+
+	/**
+	 * The '<em><b>W40</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Precipitation (present, unspecified)
+	 * <!-- end-model-doc -->
+	 * @see #W40_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W40(40, "W_40", "40"),
+
+	/**
+	 * The '<em><b>W41</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Precipitation slight/moderate
+	 * <!-- end-model-doc -->
+	 * @see #W41_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W41(41, "W_41", "41"),
+
+	/**
+	 * The '<em><b>W42</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Precipitation heavy
+	 * <!-- end-model-doc -->
+	 * @see #W42_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W42(42, "W_42", "42"),
+
+	/**
+	 * The '<em><b>W43</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Liquid precipitation slight/mod
+	 * <!-- end-model-doc -->
+	 * @see #W43_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W43(43, "W_43", "43"),
+
+	/**
+	 * The '<em><b>W44</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Liquid precipitation heavy
+	 * <!-- end-model-doc -->
+	 * @see #W44_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W44(44, "W_44", "44"),
+
+	/**
+	 * The '<em><b>W45</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Solid precipitation slight/mod
+	 * <!-- end-model-doc -->
+	 * @see #W45_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W45(45, "W_45", "45"),
+
+	/**
+	 * The '<em><b>W50</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle
+	 * <!-- end-model-doc -->
+	 * @see #W50_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W50(50, "W_50", "50"),
+
+	/**
+	 * The '<em><b>W51</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle slight
+	 * <!-- end-model-doc -->
+	 * @see #W51_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W51(51, "W_51", "51"),
+
+	/**
+	 * The '<em><b>W52</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle moderate
+	 * <!-- end-model-doc -->
+	 * @see #W52_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W52(52, "W_52", "52"),
+
+	/**
+	 * The '<em><b>W53</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle heavy
+	 * <!-- end-model-doc -->
+	 * @see #W53_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W53(53, "W_53", "53"),
+
+	/**
+	 * The '<em><b>W54</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing drizzle slight
+	 * <!-- end-model-doc -->
+	 * @see #W54_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W54(54, "W_54", "54"),
+
+	/**
+	 * The '<em><b>W55</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing drizzle moderate
+	 * <!-- end-model-doc -->
+	 * @see #W55_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W55(55, "W_55", "55"),
+
+	/**
+	 * The '<em><b>W56</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing drizzle heavy
+	 * <!-- end-model-doc -->
+	 * @see #W56_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W56(56, "W_56", "56"),
+
+	/**
+	 * The '<em><b>W57</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle & rain slight
+	 * <!-- end-model-doc -->
+	 * @see #W57_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W57(57, "W_57", "57"),
+
+	/**
+	 * The '<em><b>W58</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle & rain mod/heavy
+	 * <!-- end-model-doc -->
+	 * @see #W58_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W58(58, "W_58", "58"),
+
+	/**
+	 * The '<em><b>W60</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain
+	 * <!-- end-model-doc -->
+	 * @see #W60_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W60(60, "W_60", "60"),
+
+	/**
+	 * The '<em><b>W61</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain slight
+	 * <!-- end-model-doc -->
+	 * @see #W61_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W61(61, "W_61", "61"),
+
+	/**
+	 * The '<em><b>W62</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain moderate
+	 * <!-- end-model-doc -->
+	 * @see #W62_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W62(62, "W_62", "62"),
+
+	/**
+	 * The '<em><b>W63</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain heavy
+	 * <!-- end-model-doc -->
+	 * @see #W63_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W63(63, "W_63", "63"),
+
+	/**
+	 * The '<em><b>W64</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing rain slight
+	 * <!-- end-model-doc -->
+	 * @see #W64_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W64(64, "W_64", "64"),
+
+	/**
+	 * The '<em><b>W65</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing rain moderate
+	 * <!-- end-model-doc -->
+	 * @see #W65_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W65(65, "W_65", "65"),
+
+	/**
+	 * The '<em><b>W66</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing rain heavy
+	 * <!-- end-model-doc -->
+	 * @see #W66_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W66(66, "W_66", "66"),
+
+	/**
+	 * The '<em><b>W67</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain + snow (or drizzle) slight
+	 * <!-- end-model-doc -->
+	 * @see #W67_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W67(67, "W_67", "67"),
+
+	/**
+	 * The '<em><b>W68</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain + snow mod/heavy
+	 * <!-- end-model-doc -->
+	 * @see #W68_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W68(68, "W_68", "68"),
+
+	/**
+	 * The '<em><b>W70</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow
+	 * <!-- end-model-doc -->
+	 * @see #W70_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W70(70, "W_70", "70"),
+
+	/**
+	 * The '<em><b>W71</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow slight
+	 * <!-- end-model-doc -->
+	 * @see #W71_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W71(71, "W_71", "71"),
+
+	/**
+	 * The '<em><b>W72</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow moderate
+	 * <!-- end-model-doc -->
+	 * @see #W72_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W72(72, "W_72", "72"),
+
+	/**
+	 * The '<em><b>W73</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow heavy
+	 * <!-- end-model-doc -->
+	 * @see #W73_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W73(73, "W_73", "73"),
+
+	/**
+	 * The '<em><b>W74</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Ice pellets slight
+	 * <!-- end-model-doc -->
+	 * @see #W74_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W74(74, "W_74", "74"),
+
+	/**
+	 * The '<em><b>W75</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Ice pellets moderate
+	 * <!-- end-model-doc -->
+	 * @see #W75_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W75(75, "W_75", "75"),
+
+	/**
+	 * The '<em><b>W76</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Ice pellets heavy
+	 * <!-- end-model-doc -->
+	 * @see #W76_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W76(76, "W_76", "76"),
+
+	/**
+	 * The '<em><b>W77</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow grains
+	 * <!-- end-model-doc -->
+	 * @see #W77_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W77(77, "W_77", "77"),
+
+	/**
+	 * The '<em><b>W80</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Showers
+	 * <!-- end-model-doc -->
+	 * @see #W80_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W80(80, "W_80", "80"),
+
+	/**
+	 * The '<em><b>W81</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain showers slight
+	 * <!-- end-model-doc -->
+	 * @see #W81_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W81(81, "W_81", "81"),
+
+	/**
+	 * The '<em><b>W82</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain showers moderate
+	 * <!-- end-model-doc -->
+	 * @see #W82_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W82(82, "W_82", "82"),
+
+	/**
+	 * The '<em><b>W83</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain showers heavy
+	 * <!-- end-model-doc -->
+	 * @see #W83_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W83(83, "W_83", "83"),
+
+	/**
+	 * The '<em><b>W85</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow showers slight
+	 * <!-- end-model-doc -->
+	 * @see #W85_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W85(85, "W_85", "85"),
+
+	/**
+	 * The '<em><b>W86</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow showers moderate
+	 * <!-- end-model-doc -->
+	 * @see #W86_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W86(86, "W_86", "86"),
+
+	/**
+	 * The '<em><b>W87</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow showers heavy
+	 * <!-- end-model-doc -->
+	 * @see #W87_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W87(87, "W_87", "87"),
+
+	/**
+	 * The '<em><b>W90</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Hail showers (no thunder)
+	 * <!-- end-model-doc -->
+	 * @see #W90_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W90(90, "W_90", "90"),
+
+	/**
+	 * The '<em><b>W91</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm recent + slight rain
+	 * <!-- end-model-doc -->
+	 * @see #W91_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W91(91, "W_91", "91"),
+
+	/**
+	 * The '<em><b>W92</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm recent + mod/heavy rain
+	 * <!-- end-model-doc -->
+	 * @see #W92_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W92(92, "W_92", "92"),
+
+	/**
+	 * The '<em><b>W93</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm recent + slight snow/hail
+	 * <!-- end-model-doc -->
+	 * @see #W93_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W93(93, "W_93", "93"),
+
+	/**
+	 * The '<em><b>W94</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm recent + mod/heavy snow/hail
+	 * <!-- end-model-doc -->
+	 * @see #W94_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W94(94, "W_94", "94"),
+
+	/**
+	 * The '<em><b>W95</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm, no hail (slight or moderate)
+	 * <!-- end-model-doc -->
+	 * @see #W95_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W95(95, "W_95", "95"),
+
+	/**
+	 * The '<em><b>W96</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm with slight hail
+	 * <!-- end-model-doc -->
+	 * @see #W96_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W96(96, "W_96", "96"),
+
+	/**
+	 * The '<em><b>W97</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm, heavy, no hail
+	 * <!-- end-model-doc -->
+	 * @see #W97_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W97(97, "W_97", "97"),
+
+	/**
+	 * The '<em><b>W98</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm with dust or sandstorm
+	 * <!-- end-model-doc -->
+	 * @see #W98_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W98(98, "W_98", "98"),
+
+	/**
+	 * The '<em><b>W99</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm with heavy hail
+	 * <!-- end-model-doc -->
+	 * @see #W99_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	W99(99, "W_99", "99"),
+
+	/**
+	 * The '<em><b>WUNKNOWN</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * No value was set
+	 * <!-- end-model-doc -->
+	 * @see #WUNKNOWN_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	WUNKNOWN(1000, "W_UNKNOWN", "UNKNOWN");
+
+	/**
+	 * The '<em><b>W00</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * No change in cloud cover (MOSMIX-specific)
+	 * <!-- end-model-doc -->
+	 * @see #W00
+	 * @model name="W_00" literal="00"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W00_VALUE = 0;
+
+	/**
+	 * The '<em><b>W01</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Cloudiness is decreasing (MOSMIX-specific)
+	 * <!-- end-model-doc -->
+	 * @see #W01
+	 * @model name="W_01" literal="01"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W01_VALUE = 1;
+
+	/**
+	 * The '<em><b>W02</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Cloudiness remains unchanged (MOSMIX-specific)
+	 * <!-- end-model-doc -->
+	 * @see #W02
+	 * @model name="W_02" literal="02"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W02_VALUE = 2;
+
+	/**
+	 * The '<em><b>W03</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Cloudiness is increasing (MOSMIX-specific)
+	 * <!-- end-model-doc -->
+	 * @see #W03
+	 * @model name="W_03" literal="03"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W03_VALUE = 3;
+
+	/**
+	 * The '<em><b>W04</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Haze, smoke, dust, visibility ≥ 1 km
+	 * <!-- end-model-doc -->
+	 * @see #W04
+	 * @model name="W_04" literal="04"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W04_VALUE = 4;
+
+	/**
+	 * The '<em><b>W05</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Haze, smoke, dust, visibility < 1 km
+	 * <!-- end-model-doc -->
+	 * @see #W05
+	 * @model name="W_05" literal="05"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W05_VALUE = 5;
+
+	/**
+	 * The '<em><b>W10</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Mist
+	 * <!-- end-model-doc -->
+	 * @see #W10
+	 * @model name="W_10" literal="10"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W10_VALUE = 10;
+
+	/**
+	 * The '<em><b>W20</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Fog
+	 * <!-- end-model-doc -->
+	 * @see #W20
+	 * @model name="W_20" literal="20"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W20_VALUE = 20;
+
+	/**
+	 * The '<em><b>W21</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Precipitation (recent, unspecified)
+	 * <!-- end-model-doc -->
+	 * @see #W21
+	 * @model name="W_21" literal="21"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W21_VALUE = 21;
+
+	/**
+	 * The '<em><b>W22</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle or snow grains (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W22
+	 * @model name="W_22" literal="22"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W22_VALUE = 22;
+
+	/**
+	 * The '<em><b>W23</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W23
+	 * @model name="W_23" literal="23"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W23_VALUE = 23;
+
+	/**
+	 * The '<em><b>W24</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W24
+	 * @model name="W_24" literal="24"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W24_VALUE = 24;
+
+	/**
+	 * The '<em><b>W25</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing rain/drizzle (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W25
+	 * @model name="W_25" literal="25"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W25_VALUE = 25;
+
+	/**
+	 * The '<em><b>W26</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W26
+	 * @model name="W_26" literal="26"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W26_VALUE = 26;
+
+	/**
+	 * The '<em><b>W27</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Blowing snow or sand (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W27
+	 * @model name="W_27" literal="27"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W27_VALUE = 27;
+
+	/**
+	 * The '<em><b>W28</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Blowing snow/sand, V ≥ 1 km (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W28
+	 * @model name="W_28" literal="28"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W28_VALUE = 28;
+
+	/**
+	 * The '<em><b>W29</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Blowing snow/sand, V < 1 km (recent)
+	 * <!-- end-model-doc -->
+	 * @see #W29
+	 * @model name="W_29" literal="29"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W29_VALUE = 29;
+
+	/**
+	 * The '<em><b>W30</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Fog
+	 * <!-- end-model-doc -->
+	 * @see #W30
+	 * @model name="W_30" literal="30"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W30_VALUE = 30;
+
+	/**
+	 * The '<em><b>W31</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Patches of fog
+	 * <!-- end-model-doc -->
+	 * @see #W31
+	 * @model name="W_31" literal="31"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W31_VALUE = 31;
+
+	/**
+	 * The '<em><b>W32</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Fog — thinning
+	 * <!-- end-model-doc -->
+	 * @see #W32
+	 * @model name="W_32" literal="32"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W32_VALUE = 32;
+
+	/**
+	 * The '<em><b>W33</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Fog — no change
+	 * <!-- end-model-doc -->
+	 * @see #W33
+	 * @model name="W_33" literal="33"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W33_VALUE = 33;
+
+	/**
+	 * The '<em><b>W34</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Fog — thickening
+	 * <!-- end-model-doc -->
+	 * @see #W34
+	 * @model name="W_34" literal="34"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W34_VALUE = 34;
+
+	/**
+	 * The '<em><b>W35</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rime fog
+	 * <!-- end-model-doc -->
+	 * @see #W35
+	 * @model name="W_35" literal="35"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W35_VALUE = 35;
+
+	/**
+	 * The '<em><b>W40</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Precipitation (present, unspecified)
+	 * <!-- end-model-doc -->
+	 * @see #W40
+	 * @model name="W_40" literal="40"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W40_VALUE = 40;
+
+	/**
+	 * The '<em><b>W41</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Precipitation slight/moderate
+	 * <!-- end-model-doc -->
+	 * @see #W41
+	 * @model name="W_41" literal="41"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W41_VALUE = 41;
+
+	/**
+	 * The '<em><b>W42</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Precipitation heavy
+	 * <!-- end-model-doc -->
+	 * @see #W42
+	 * @model name="W_42" literal="42"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W42_VALUE = 42;
+
+	/**
+	 * The '<em><b>W43</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Liquid precipitation slight/mod
+	 * <!-- end-model-doc -->
+	 * @see #W43
+	 * @model name="W_43" literal="43"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W43_VALUE = 43;
+
+	/**
+	 * The '<em><b>W44</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Liquid precipitation heavy
+	 * <!-- end-model-doc -->
+	 * @see #W44
+	 * @model name="W_44" literal="44"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W44_VALUE = 44;
+
+	/**
+	 * The '<em><b>W45</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Solid precipitation slight/mod
+	 * <!-- end-model-doc -->
+	 * @see #W45
+	 * @model name="W_45" literal="45"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W45_VALUE = 45;
+
+	/**
+	 * The '<em><b>W50</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle
+	 * <!-- end-model-doc -->
+	 * @see #W50
+	 * @model name="W_50" literal="50"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W50_VALUE = 50;
+
+	/**
+	 * The '<em><b>W51</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle slight
+	 * <!-- end-model-doc -->
+	 * @see #W51
+	 * @model name="W_51" literal="51"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W51_VALUE = 51;
+
+	/**
+	 * The '<em><b>W52</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle moderate
+	 * <!-- end-model-doc -->
+	 * @see #W52
+	 * @model name="W_52" literal="52"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W52_VALUE = 52;
+
+	/**
+	 * The '<em><b>W53</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle heavy
+	 * <!-- end-model-doc -->
+	 * @see #W53
+	 * @model name="W_53" literal="53"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W53_VALUE = 53;
+
+	/**
+	 * The '<em><b>W54</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing drizzle slight
+	 * <!-- end-model-doc -->
+	 * @see #W54
+	 * @model name="W_54" literal="54"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W54_VALUE = 54;
+
+	/**
+	 * The '<em><b>W55</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing drizzle moderate
+	 * <!-- end-model-doc -->
+	 * @see #W55
+	 * @model name="W_55" literal="55"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W55_VALUE = 55;
+
+	/**
+	 * The '<em><b>W56</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing drizzle heavy
+	 * <!-- end-model-doc -->
+	 * @see #W56
+	 * @model name="W_56" literal="56"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W56_VALUE = 56;
+
+	/**
+	 * The '<em><b>W57</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle & rain slight
+	 * <!-- end-model-doc -->
+	 * @see #W57
+	 * @model name="W_57" literal="57"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W57_VALUE = 57;
+
+	/**
+	 * The '<em><b>W58</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Drizzle & rain mod/heavy
+	 * <!-- end-model-doc -->
+	 * @see #W58
+	 * @model name="W_58" literal="58"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W58_VALUE = 58;
+
+	/**
+	 * The '<em><b>W60</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain
+	 * <!-- end-model-doc -->
+	 * @see #W60
+	 * @model name="W_60" literal="60"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W60_VALUE = 60;
+
+	/**
+	 * The '<em><b>W61</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain slight
+	 * <!-- end-model-doc -->
+	 * @see #W61
+	 * @model name="W_61" literal="61"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W61_VALUE = 61;
+
+	/**
+	 * The '<em><b>W62</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain moderate
+	 * <!-- end-model-doc -->
+	 * @see #W62
+	 * @model name="W_62" literal="62"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W62_VALUE = 62;
+
+	/**
+	 * The '<em><b>W63</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain heavy
+	 * <!-- end-model-doc -->
+	 * @see #W63
+	 * @model name="W_63" literal="63"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W63_VALUE = 63;
+
+	/**
+	 * The '<em><b>W64</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing rain slight
+	 * <!-- end-model-doc -->
+	 * @see #W64
+	 * @model name="W_64" literal="64"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W64_VALUE = 64;
+
+	/**
+	 * The '<em><b>W65</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing rain moderate
+	 * <!-- end-model-doc -->
+	 * @see #W65
+	 * @model name="W_65" literal="65"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W65_VALUE = 65;
+
+	/**
+	 * The '<em><b>W66</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Freezing rain heavy
+	 * <!-- end-model-doc -->
+	 * @see #W66
+	 * @model name="W_66" literal="66"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W66_VALUE = 66;
+
+	/**
+	 * The '<em><b>W67</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain + snow (or drizzle) slight
+	 * <!-- end-model-doc -->
+	 * @see #W67
+	 * @model name="W_67" literal="67"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W67_VALUE = 67;
+
+	/**
+	 * The '<em><b>W68</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain + snow mod/heavy
+	 * <!-- end-model-doc -->
+	 * @see #W68
+	 * @model name="W_68" literal="68"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W68_VALUE = 68;
+
+	/**
+	 * The '<em><b>W70</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow
+	 * <!-- end-model-doc -->
+	 * @see #W70
+	 * @model name="W_70" literal="70"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W70_VALUE = 70;
+
+	/**
+	 * The '<em><b>W71</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow slight
+	 * <!-- end-model-doc -->
+	 * @see #W71
+	 * @model name="W_71" literal="71"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W71_VALUE = 71;
+
+	/**
+	 * The '<em><b>W72</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow moderate
+	 * <!-- end-model-doc -->
+	 * @see #W72
+	 * @model name="W_72" literal="72"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W72_VALUE = 72;
+
+	/**
+	 * The '<em><b>W73</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow heavy
+	 * <!-- end-model-doc -->
+	 * @see #W73
+	 * @model name="W_73" literal="73"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W73_VALUE = 73;
+
+	/**
+	 * The '<em><b>W74</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Ice pellets slight
+	 * <!-- end-model-doc -->
+	 * @see #W74
+	 * @model name="W_74" literal="74"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W74_VALUE = 74;
+
+	/**
+	 * The '<em><b>W75</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Ice pellets moderate
+	 * <!-- end-model-doc -->
+	 * @see #W75
+	 * @model name="W_75" literal="75"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W75_VALUE = 75;
+
+	/**
+	 * The '<em><b>W76</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Ice pellets heavy
+	 * <!-- end-model-doc -->
+	 * @see #W76
+	 * @model name="W_76" literal="76"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W76_VALUE = 76;
+
+	/**
+	 * The '<em><b>W77</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow grains
+	 * <!-- end-model-doc -->
+	 * @see #W77
+	 * @model name="W_77" literal="77"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W77_VALUE = 77;
+
+	/**
+	 * The '<em><b>W80</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Showers
+	 * <!-- end-model-doc -->
+	 * @see #W80
+	 * @model name="W_80" literal="80"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W80_VALUE = 80;
+
+	/**
+	 * The '<em><b>W81</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain showers slight
+	 * <!-- end-model-doc -->
+	 * @see #W81
+	 * @model name="W_81" literal="81"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W81_VALUE = 81;
+
+	/**
+	 * The '<em><b>W82</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain showers moderate
+	 * <!-- end-model-doc -->
+	 * @see #W82
+	 * @model name="W_82" literal="82"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W82_VALUE = 82;
+
+	/**
+	 * The '<em><b>W83</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Rain showers heavy
+	 * <!-- end-model-doc -->
+	 * @see #W83
+	 * @model name="W_83" literal="83"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W83_VALUE = 83;
+
+	/**
+	 * The '<em><b>W85</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow showers slight
+	 * <!-- end-model-doc -->
+	 * @see #W85
+	 * @model name="W_85" literal="85"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W85_VALUE = 85;
+
+	/**
+	 * The '<em><b>W86</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow showers moderate
+	 * <!-- end-model-doc -->
+	 * @see #W86
+	 * @model name="W_86" literal="86"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W86_VALUE = 86;
+
+	/**
+	 * The '<em><b>W87</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Snow showers heavy
+	 * <!-- end-model-doc -->
+	 * @see #W87
+	 * @model name="W_87" literal="87"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W87_VALUE = 87;
+
+	/**
+	 * The '<em><b>W90</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Hail showers (no thunder)
+	 * <!-- end-model-doc -->
+	 * @see #W90
+	 * @model name="W_90" literal="90"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W90_VALUE = 90;
+
+	/**
+	 * The '<em><b>W91</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm recent + slight rain
+	 * <!-- end-model-doc -->
+	 * @see #W91
+	 * @model name="W_91" literal="91"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W91_VALUE = 91;
+
+	/**
+	 * The '<em><b>W92</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm recent + mod/heavy rain
+	 * <!-- end-model-doc -->
+	 * @see #W92
+	 * @model name="W_92" literal="92"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W92_VALUE = 92;
+
+	/**
+	 * The '<em><b>W93</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm recent + slight snow/hail
+	 * <!-- end-model-doc -->
+	 * @see #W93
+	 * @model name="W_93" literal="93"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W93_VALUE = 93;
+
+	/**
+	 * The '<em><b>W94</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm recent + mod/heavy snow/hail
+	 * <!-- end-model-doc -->
+	 * @see #W94
+	 * @model name="W_94" literal="94"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W94_VALUE = 94;
+
+	/**
+	 * The '<em><b>W95</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm, no hail (slight or moderate)
+	 * <!-- end-model-doc -->
+	 * @see #W95
+	 * @model name="W_95" literal="95"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W95_VALUE = 95;
+
+	/**
+	 * The '<em><b>W96</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm with slight hail
+	 * <!-- end-model-doc -->
+	 * @see #W96
+	 * @model name="W_96" literal="96"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W96_VALUE = 96;
+
+	/**
+	 * The '<em><b>W97</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm, heavy, no hail
+	 * <!-- end-model-doc -->
+	 * @see #W97
+	 * @model name="W_97" literal="97"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W97_VALUE = 97;
+
+	/**
+	 * The '<em><b>W98</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm with dust or sandstorm
+	 * <!-- end-model-doc -->
+	 * @see #W98
+	 * @model name="W_98" literal="98"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W98_VALUE = 98;
+
+	/**
+	 * The '<em><b>W99</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Thunderstorm with heavy hail
+	 * <!-- end-model-doc -->
+	 * @see #W99
+	 * @model name="W_99" literal="99"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int W99_VALUE = 99;
+
+	/**
+	 * The '<em><b>WUNKNOWN</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * No value was set
+	 * <!-- end-model-doc -->
+	 * @see #WUNKNOWN
+	 * @model name="W_UNKNOWN" literal="UNKNOWN"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int WUNKNOWN_VALUE = 1000;
+
+	/**
+	 * An array of all the '<em><b>WMO Weather Code Type</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private static final WMOWeatherCodeType[] VALUES_ARRAY =
+		new WMOWeatherCodeType[] {
+			W00,
+			W01,
+			W02,
+			W03,
+			W04,
+			W05,
+			W10,
+			W20,
+			W21,
+			W22,
+			W23,
+			W24,
+			W25,
+			W26,
+			W27,
+			W28,
+			W29,
+			W30,
+			W31,
+			W32,
+			W33,
+			W34,
+			W35,
+			W40,
+			W41,
+			W42,
+			W43,
+			W44,
+			W45,
+			W50,
+			W51,
+			W52,
+			W53,
+			W54,
+			W55,
+			W56,
+			W57,
+			W58,
+			W60,
+			W61,
+			W62,
+			W63,
+			W64,
+			W65,
+			W66,
+			W67,
+			W68,
+			W70,
+			W71,
+			W72,
+			W73,
+			W74,
+			W75,
+			W76,
+			W77,
+			W80,
+			W81,
+			W82,
+			W83,
+			W85,
+			W86,
+			W87,
+			W90,
+			W91,
+			W92,
+			W93,
+			W94,
+			W95,
+			W96,
+			W97,
+			W98,
+			W99,
+			WUNKNOWN,
+		};
+
+	/**
+	 * A public read-only list of all the '<em><b>WMO Weather Code Type</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static final List<WMOWeatherCodeType> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
+
+	/**
+	 * Returns the '<em><b>WMO Weather Code Type</b></em>' literal with the specified literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param literal the literal.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static WMOWeatherCodeType get(String literal) {
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			WMOWeatherCodeType result = VALUES_ARRAY[i];
+			if (result.toString().equals(literal)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>WMO Weather Code Type</b></em>' literal with the specified name.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param name the name.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static WMOWeatherCodeType getByName(String name) {
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			WMOWeatherCodeType result = VALUES_ARRAY[i];
+			if (result.getName().equals(name)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>WMO Weather Code Type</b></em>' literal with the specified integer value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the integer value.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static WMOWeatherCodeType get(int value) {
+		switch (value) {
+			case W00_VALUE: return W00;
+			case W01_VALUE: return W01;
+			case W02_VALUE: return W02;
+			case W03_VALUE: return W03;
+			case W04_VALUE: return W04;
+			case W05_VALUE: return W05;
+			case W10_VALUE: return W10;
+			case W20_VALUE: return W20;
+			case W21_VALUE: return W21;
+			case W22_VALUE: return W22;
+			case W23_VALUE: return W23;
+			case W24_VALUE: return W24;
+			case W25_VALUE: return W25;
+			case W26_VALUE: return W26;
+			case W27_VALUE: return W27;
+			case W28_VALUE: return W28;
+			case W29_VALUE: return W29;
+			case W30_VALUE: return W30;
+			case W31_VALUE: return W31;
+			case W32_VALUE: return W32;
+			case W33_VALUE: return W33;
+			case W34_VALUE: return W34;
+			case W35_VALUE: return W35;
+			case W40_VALUE: return W40;
+			case W41_VALUE: return W41;
+			case W42_VALUE: return W42;
+			case W43_VALUE: return W43;
+			case W44_VALUE: return W44;
+			case W45_VALUE: return W45;
+			case W50_VALUE: return W50;
+			case W51_VALUE: return W51;
+			case W52_VALUE: return W52;
+			case W53_VALUE: return W53;
+			case W54_VALUE: return W54;
+			case W55_VALUE: return W55;
+			case W56_VALUE: return W56;
+			case W57_VALUE: return W57;
+			case W58_VALUE: return W58;
+			case W60_VALUE: return W60;
+			case W61_VALUE: return W61;
+			case W62_VALUE: return W62;
+			case W63_VALUE: return W63;
+			case W64_VALUE: return W64;
+			case W65_VALUE: return W65;
+			case W66_VALUE: return W66;
+			case W67_VALUE: return W67;
+			case W68_VALUE: return W68;
+			case W70_VALUE: return W70;
+			case W71_VALUE: return W71;
+			case W72_VALUE: return W72;
+			case W73_VALUE: return W73;
+			case W74_VALUE: return W74;
+			case W75_VALUE: return W75;
+			case W76_VALUE: return W76;
+			case W77_VALUE: return W77;
+			case W80_VALUE: return W80;
+			case W81_VALUE: return W81;
+			case W82_VALUE: return W82;
+			case W83_VALUE: return W83;
+			case W85_VALUE: return W85;
+			case W86_VALUE: return W86;
+			case W87_VALUE: return W87;
+			case W90_VALUE: return W90;
+			case W91_VALUE: return W91;
+			case W92_VALUE: return W92;
+			case W93_VALUE: return W93;
+			case W94_VALUE: return W94;
+			case W95_VALUE: return W95;
+			case W96_VALUE: return W96;
+			case W97_VALUE: return W97;
+			case W98_VALUE: return W98;
+			case W99_VALUE: return W99;
+			case WUNKNOWN_VALUE: return WUNKNOWN;
+		}
+		return null;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final int value;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final String name;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final String literal;
+
+	/**
+	 * Only this class can construct instances.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private WMOWeatherCodeType(int value, String name, String literal) {
+		this.value = value;
+		this.name = name;
+		this.literal = literal;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public int getValue() {
+	  return value;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String getName() {
+	  return name;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String getLiteral() {
+	  return literal;
+	}
+
+	/**
+	 * Returns the literal value of the enumerator, which is its string representation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		return literal;
+	}
+	
+} //WMOWeatherCodeType

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/WeatherFactory.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/WeatherFactory.java
@@ -171,6 +171,15 @@ public interface WeatherFactory extends EFactory {
 	WeatherStation createWeatherStation();
 
 	/**
+	 * Returns a new object of class '<em>W1W2</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>W1W2</em>'.
+	 * @generated
+	 */
+	W1W2 createW1W2();
+
+	/**
 	 * Returns the package supported by this factory.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/WeatherPackage.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/WeatherPackage.java
@@ -16,6 +16,7 @@ package org.gecko.weather.model.weather;
 
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EEnum;
 import org.eclipse.emf.ecore.EReference;
 
 import org.gecko.emf.osgi.annotation.provide.EPackage;
@@ -1194,22 +1195,22 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 	int MOSMIXS_WEATHER_REPORT__VISIBILITY = WEATHER_REPORT_FEATURE_COUNT + 34;
 
 	/**
-	 * The feature id for the '<em><b>Past Weather</b></em>' attribute.
+	 * The feature id for the '<em><b>Significant Weather6 Hours</b></em>' containment reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int MOSMIXS_WEATHER_REPORT__PAST_WEATHER = WEATHER_REPORT_FEATURE_COUNT + 35;
+	int MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS = WEATHER_REPORT_FEATURE_COUNT + 35;
 
 	/**
-	 * The feature id for the '<em><b>Significant Weather</b></em>' attribute.
+	 * The feature id for the '<em><b>Significant Weather3 Hours</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER = WEATHER_REPORT_FEATURE_COUNT + 36;
+	int MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER3_HOURS = WEATHER_REPORT_FEATURE_COUNT + 36;
 
 	/**
 	 * The feature id for the '<em><b>Fog Prop Last1</b></em>' attribute.
@@ -1474,6 +1475,62 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 	 * @ordered
 	 */
 	int WEATHER_STATION_OPERATION_COUNT = STATION_OPERATION_COUNT + 0;
+
+	/**
+	 * The meta object id for the '{@link org.gecko.weather.model.weather.impl.W1W2Impl <em>W1W2</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.gecko.weather.model.weather.impl.W1W2Impl
+	 * @see org.gecko.weather.model.weather.impl.WeatherPackageImpl#getW1W2()
+	 * @generated
+	 */
+	int W1W2 = 15;
+
+	/**
+	 * The feature id for the '<em><b>W1</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int W1W2__W1 = 0;
+
+	/**
+	 * The feature id for the '<em><b>W2</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int W1W2__W2 = 1;
+
+	/**
+	 * The number of structural features of the '<em>W1W2</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int W1W2_FEATURE_COUNT = 2;
+
+	/**
+	 * The number of operations of the '<em>W1W2</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int W1W2_OPERATION_COUNT = 0;
+
+	/**
+	 * The meta object id for the '{@link org.gecko.weather.model.weather.WMOWeatherCodeType <em>WMO Weather Code Type</em>}' enum.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.gecko.weather.model.weather.WMOWeatherCodeType
+	 * @see org.gecko.weather.model.weather.impl.WeatherPackageImpl#getWMOWeatherCodeType()
+	 * @generated
+	 */
+	int WMO_WEATHER_CODE_TYPE = 16;
 
 
 	/**
@@ -2246,26 +2303,26 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 	EAttribute getMOSMIXSWeatherReport_Visibility();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getPastWeather <em>Past Weather</em>}'.
+	 * Returns the meta object for the containment reference '{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getSignificantWeather6Hours <em>Significant Weather6 Hours</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @return the meta object for the attribute '<em>Past Weather</em>'.
-	 * @see org.gecko.weather.model.weather.MOSMIXSWeatherReport#getPastWeather()
+	 * @return the meta object for the containment reference '<em>Significant Weather6 Hours</em>'.
+	 * @see org.gecko.weather.model.weather.MOSMIXSWeatherReport#getSignificantWeather6Hours()
 	 * @see #getMOSMIXSWeatherReport()
 	 * @generated
 	 */
-	EAttribute getMOSMIXSWeatherReport_PastWeather();
+	EReference getMOSMIXSWeatherReport_SignificantWeather6Hours();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getSignificantWeather <em>Significant Weather</em>}'.
+	 * Returns the meta object for the attribute '{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getSignificantWeather3Hours <em>Significant Weather3 Hours</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @return the meta object for the attribute '<em>Significant Weather</em>'.
-	 * @see org.gecko.weather.model.weather.MOSMIXSWeatherReport#getSignificantWeather()
+	 * @return the meta object for the attribute '<em>Significant Weather3 Hours</em>'.
+	 * @see org.gecko.weather.model.weather.MOSMIXSWeatherReport#getSignificantWeather3Hours()
 	 * @see #getMOSMIXSWeatherReport()
 	 * @generated
 	 */
-	EAttribute getMOSMIXSWeatherReport_SignificantWeather();
+	EAttribute getMOSMIXSWeatherReport_SignificantWeather3Hours();
 
 	/**
 	 * Returns the meta object for the attribute '{@link org.gecko.weather.model.weather.MOSMIXSWeatherReport#getFogPropLast1 <em>Fog Prop Last1</em>}'.
@@ -2406,6 +2463,48 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 	 * @generated
 	 */
 	EAttribute getWeatherStation_IcaoCode();
+
+	/**
+	 * Returns the meta object for class '{@link org.gecko.weather.model.weather.W1W2 <em>W1W2</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>W1W2</em>'.
+	 * @see org.gecko.weather.model.weather.W1W2
+	 * @generated
+	 */
+	EClass getW1W2();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.gecko.weather.model.weather.W1W2#getW1 <em>W1</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>W1</em>'.
+	 * @see org.gecko.weather.model.weather.W1W2#getW1()
+	 * @see #getW1W2()
+	 * @generated
+	 */
+	EAttribute getW1W2_W1();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.gecko.weather.model.weather.W1W2#getW2 <em>W2</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>W2</em>'.
+	 * @see org.gecko.weather.model.weather.W1W2#getW2()
+	 * @see #getW1W2()
+	 * @generated
+	 */
+	EAttribute getW1W2_W2();
+
+	/**
+	 * Returns the meta object for enum '{@link org.gecko.weather.model.weather.WMOWeatherCodeType <em>WMO Weather Code Type</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for enum '<em>WMO Weather Code Type</em>'.
+	 * @see org.gecko.weather.model.weather.WMOWeatherCodeType
+	 * @generated
+	 */
+	EEnum getWMOWeatherCodeType();
 
 	/**
 	 * Returns the factory that creates the instances of the model.
@@ -3023,20 +3122,20 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 		EAttribute MOSMIXS_WEATHER_REPORT__VISIBILITY = eINSTANCE.getMOSMIXSWeatherReport_Visibility();
 
 		/**
-		 * The meta object literal for the '<em><b>Past Weather</b></em>' attribute feature.
+		 * The meta object literal for the '<em><b>Significant Weather6 Hours</b></em>' containment reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
 		 * @generated
 		 */
-		EAttribute MOSMIXS_WEATHER_REPORT__PAST_WEATHER = eINSTANCE.getMOSMIXSWeatherReport_PastWeather();
+		EReference MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS = eINSTANCE.getMOSMIXSWeatherReport_SignificantWeather6Hours();
 
 		/**
-		 * The meta object literal for the '<em><b>Significant Weather</b></em>' attribute feature.
+		 * The meta object literal for the '<em><b>Significant Weather3 Hours</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
 		 * @generated
 		 */
-		EAttribute MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER = eINSTANCE.getMOSMIXSWeatherReport_SignificantWeather();
+		EAttribute MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER3_HOURS = eINSTANCE.getMOSMIXSWeatherReport_SignificantWeather3Hours();
 
 		/**
 		 * The meta object literal for the '<em><b>Fog Prop Last1</b></em>' attribute feature.
@@ -3147,6 +3246,42 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 		 * @generated
 		 */
 		EAttribute WEATHER_STATION__ICAO_CODE = eINSTANCE.getWeatherStation_IcaoCode();
+
+		/**
+		 * The meta object literal for the '{@link org.gecko.weather.model.weather.impl.W1W2Impl <em>W1W2</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.gecko.weather.model.weather.impl.W1W2Impl
+		 * @see org.gecko.weather.model.weather.impl.WeatherPackageImpl#getW1W2()
+		 * @generated
+		 */
+		EClass W1W2 = eINSTANCE.getW1W2();
+
+		/**
+		 * The meta object literal for the '<em><b>W1</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute W1W2__W1 = eINSTANCE.getW1W2_W1();
+
+		/**
+		 * The meta object literal for the '<em><b>W2</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute W1W2__W2 = eINSTANCE.getW1W2_W2();
+
+		/**
+		 * The meta object literal for the '{@link org.gecko.weather.model.weather.WMOWeatherCodeType <em>WMO Weather Code Type</em>}' enum.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.gecko.weather.model.weather.WMOWeatherCodeType
+		 * @see org.gecko.weather.model.weather.impl.WeatherPackageImpl#getWMOWeatherCodeType()
+		 * @generated
+		 */
+		EEnum WMO_WEATHER_CODE_TYPE = eINSTANCE.getWMOWeatherCodeType();
 
 	}
 

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/MOSMIXSWeatherReportImpl.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/MOSMIXSWeatherReportImpl.java
@@ -14,12 +14,16 @@
 package org.gecko.weather.model.weather.impl;
 
 import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.notify.NotificationChain;
 
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.gecko.weather.model.weather.MOSMIXSWeatherReport;
+import org.gecko.weather.model.weather.W1W2;
+import org.gecko.weather.model.weather.WMOWeatherCodeType;
 import org.gecko.weather.model.weather.WeatherPackage;
 
 /**
@@ -65,8 +69,8 @@ import org.gecko.weather.model.weather.WeatherPackage;
  *   <li>{@link org.gecko.weather.model.weather.impl.MOSMIXSWeatherReportImpl#getTempMinLast12 <em>Temp Min Last12</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.impl.MOSMIXSWeatherReportImpl#getTempMaxLast12 <em>Temp Max Last12</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.impl.MOSMIXSWeatherReportImpl#getVisibility <em>Visibility</em>}</li>
- *   <li>{@link org.gecko.weather.model.weather.impl.MOSMIXSWeatherReportImpl#getPastWeather <em>Past Weather</em>}</li>
- *   <li>{@link org.gecko.weather.model.weather.impl.MOSMIXSWeatherReportImpl#getSignificantWeather <em>Significant Weather</em>}</li>
+ *   <li>{@link org.gecko.weather.model.weather.impl.MOSMIXSWeatherReportImpl#getSignificantWeather6Hours <em>Significant Weather6 Hours</em>}</li>
+ *   <li>{@link org.gecko.weather.model.weather.impl.MOSMIXSWeatherReportImpl#getSignificantWeather3Hours <em>Significant Weather3 Hours</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.impl.MOSMIXSWeatherReportImpl#getFogPropLast1 <em>Fog Prop Last1</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.impl.MOSMIXSWeatherReportImpl#getFogPropLast6 <em>Fog Prop Last6</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.impl.MOSMIXSWeatherReportImpl#getFogPropLast12 <em>Fog Prop Last12</em>}</li>
@@ -776,44 +780,34 @@ public class MOSMIXSWeatherReportImpl extends WeatherReportImpl implements MOSMI
 	protected Float visibility = VISIBILITY_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getPastWeather() <em>Past Weather</em>}' attribute.
+	 * The cached value of the '{@link #getSignificantWeather6Hours() <em>Significant Weather6 Hours</em>}' containment reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #getPastWeather()
+	 * @see #getSignificantWeather6Hours()
 	 * @generated
 	 * @ordered
 	 */
-	protected static final Float PAST_WEATHER_EDEFAULT = null;
+	protected W1W2 significantWeather6Hours;
 
 	/**
-	 * The cached value of the '{@link #getPastWeather() <em>Past Weather</em>}' attribute.
+	 * The default value of the '{@link #getSignificantWeather3Hours() <em>Significant Weather3 Hours</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #getPastWeather()
+	 * @see #getSignificantWeather3Hours()
 	 * @generated
 	 * @ordered
 	 */
-	protected Float pastWeather = PAST_WEATHER_EDEFAULT;
+	protected static final WMOWeatherCodeType SIGNIFICANT_WEATHER3_HOURS_EDEFAULT = WMOWeatherCodeType.WUNKNOWN;
 
 	/**
-	 * The default value of the '{@link #getSignificantWeather() <em>Significant Weather</em>}' attribute.
+	 * The cached value of the '{@link #getSignificantWeather3Hours() <em>Significant Weather3 Hours</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #getSignificantWeather()
+	 * @see #getSignificantWeather3Hours()
 	 * @generated
 	 * @ordered
 	 */
-	protected static final Float SIGNIFICANT_WEATHER_EDEFAULT = null;
-
-	/**
-	 * The cached value of the '{@link #getSignificantWeather() <em>Significant Weather</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see #getSignificantWeather()
-	 * @generated
-	 * @ordered
-	 */
-	protected Float significantWeather = SIGNIFICANT_WEATHER_EDEFAULT;
+	protected WMOWeatherCodeType significantWeather3Hours = SIGNIFICANT_WEATHER3_HOURS_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getFogPropLast1() <em>Fog Prop Last1</em>}' attribute.
@@ -1705,8 +1699,23 @@ public class MOSMIXSWeatherReportImpl extends WeatherReportImpl implements MOSMI
 	 * @generated
 	 */
 	@Override
-	public Float getPastWeather() {
-		return pastWeather;
+	public W1W2 getSignificantWeather6Hours() {
+		return significantWeather6Hours;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public NotificationChain basicSetSignificantWeather6Hours(W1W2 newSignificantWeather6Hours, NotificationChain msgs) {
+		W1W2 oldSignificantWeather6Hours = significantWeather6Hours;
+		significantWeather6Hours = newSignificantWeather6Hours;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS, oldSignificantWeather6Hours, newSignificantWeather6Hours);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
 	}
 
 	/**
@@ -1715,34 +1724,41 @@ public class MOSMIXSWeatherReportImpl extends WeatherReportImpl implements MOSMI
 	 * @generated
 	 */
 	@Override
-	public void setPastWeather(Float newPastWeather) {
-		Float oldPastWeather = pastWeather;
-		pastWeather = newPastWeather;
+	public void setSignificantWeather6Hours(W1W2 newSignificantWeather6Hours) {
+		if (newSignificantWeather6Hours != significantWeather6Hours) {
+			NotificationChain msgs = null;
+			if (significantWeather6Hours != null)
+				msgs = ((InternalEObject)significantWeather6Hours).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS, null, msgs);
+			if (newSignificantWeather6Hours != null)
+				msgs = ((InternalEObject)newSignificantWeather6Hours).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS, null, msgs);
+			msgs = basicSetSignificantWeather6Hours(newSignificantWeather6Hours, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS, newSignificantWeather6Hours, newSignificantWeather6Hours));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public WMOWeatherCodeType getSignificantWeather3Hours() {
+		return significantWeather3Hours;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setSignificantWeather3Hours(WMOWeatherCodeType newSignificantWeather3Hours) {
+		WMOWeatherCodeType oldSignificantWeather3Hours = significantWeather3Hours;
+		significantWeather3Hours = newSignificantWeather3Hours == null ? SIGNIFICANT_WEATHER3_HOURS_EDEFAULT : newSignificantWeather3Hours;
 		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, WeatherPackage.MOSMIXS_WEATHER_REPORT__PAST_WEATHER, oldPastWeather, pastWeather));
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public Float getSignificantWeather() {
-		return significantWeather;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public void setSignificantWeather(Float newSignificantWeather) {
-		Float oldSignificantWeather = significantWeather;
-		significantWeather = newSignificantWeather;
-		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER, oldSignificantWeather, significantWeather));
+			eNotify(new ENotificationImpl(this, Notification.SET, WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER3_HOURS, oldSignificantWeather3Hours, significantWeather3Hours));
 	}
 
 	/**
@@ -1812,6 +1828,20 @@ public class MOSMIXSWeatherReportImpl extends WeatherReportImpl implements MOSMI
 		fogPropLast12 = newFogPropLast12;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, WeatherPackage.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST12, oldFogPropLast12, fogPropLast12));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
+		switch (featureID) {
+			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS:
+				return basicSetSignificantWeather6Hours(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
 	}
 
 	/**
@@ -1892,10 +1922,10 @@ public class MOSMIXSWeatherReportImpl extends WeatherReportImpl implements MOSMI
 				return getTempMaxLast12();
 			case WeatherPackage.MOSMIXS_WEATHER_REPORT__VISIBILITY:
 				return getVisibility();
-			case WeatherPackage.MOSMIXS_WEATHER_REPORT__PAST_WEATHER:
-				return getPastWeather();
-			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER:
-				return getSignificantWeather();
+			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS:
+				return getSignificantWeather6Hours();
+			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER3_HOURS:
+				return getSignificantWeather3Hours();
 			case WeatherPackage.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST1:
 				return getFogPropLast1();
 			case WeatherPackage.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST6:
@@ -2019,11 +2049,11 @@ public class MOSMIXSWeatherReportImpl extends WeatherReportImpl implements MOSMI
 			case WeatherPackage.MOSMIXS_WEATHER_REPORT__VISIBILITY:
 				setVisibility((Float)newValue);
 				return;
-			case WeatherPackage.MOSMIXS_WEATHER_REPORT__PAST_WEATHER:
-				setPastWeather((Float)newValue);
+			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS:
+				setSignificantWeather6Hours((W1W2)newValue);
 				return;
-			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER:
-				setSignificantWeather((Float)newValue);
+			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER3_HOURS:
+				setSignificantWeather3Hours((WMOWeatherCodeType)newValue);
 				return;
 			case WeatherPackage.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST1:
 				setFogPropLast1((Float)newValue);
@@ -2151,11 +2181,11 @@ public class MOSMIXSWeatherReportImpl extends WeatherReportImpl implements MOSMI
 			case WeatherPackage.MOSMIXS_WEATHER_REPORT__VISIBILITY:
 				setVisibility(VISIBILITY_EDEFAULT);
 				return;
-			case WeatherPackage.MOSMIXS_WEATHER_REPORT__PAST_WEATHER:
-				setPastWeather(PAST_WEATHER_EDEFAULT);
+			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS:
+				setSignificantWeather6Hours((W1W2)null);
 				return;
-			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER:
-				setSignificantWeather(SIGNIFICANT_WEATHER_EDEFAULT);
+			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER3_HOURS:
+				setSignificantWeather3Hours(SIGNIFICANT_WEATHER3_HOURS_EDEFAULT);
 				return;
 			case WeatherPackage.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST1:
 				setFogPropLast1(FOG_PROP_LAST1_EDEFAULT);
@@ -2248,10 +2278,10 @@ public class MOSMIXSWeatherReportImpl extends WeatherReportImpl implements MOSMI
 				return TEMP_MAX_LAST12_EDEFAULT == null ? tempMaxLast12 != null : !TEMP_MAX_LAST12_EDEFAULT.equals(tempMaxLast12);
 			case WeatherPackage.MOSMIXS_WEATHER_REPORT__VISIBILITY:
 				return VISIBILITY_EDEFAULT == null ? visibility != null : !VISIBILITY_EDEFAULT.equals(visibility);
-			case WeatherPackage.MOSMIXS_WEATHER_REPORT__PAST_WEATHER:
-				return PAST_WEATHER_EDEFAULT == null ? pastWeather != null : !PAST_WEATHER_EDEFAULT.equals(pastWeather);
-			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER:
-				return SIGNIFICANT_WEATHER_EDEFAULT == null ? significantWeather != null : !SIGNIFICANT_WEATHER_EDEFAULT.equals(significantWeather);
+			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS:
+				return significantWeather6Hours != null;
+			case WeatherPackage.MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER3_HOURS:
+				return significantWeather3Hours != SIGNIFICANT_WEATHER3_HOURS_EDEFAULT;
 			case WeatherPackage.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST1:
 				return FOG_PROP_LAST1_EDEFAULT == null ? fogPropLast1 != null : !FOG_PROP_LAST1_EDEFAULT.equals(fogPropLast1);
 			case WeatherPackage.MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST6:
@@ -2342,10 +2372,8 @@ public class MOSMIXSWeatherReportImpl extends WeatherReportImpl implements MOSMI
 		result.append(tempMaxLast12);
 		result.append(", visibility: ");
 		result.append(visibility);
-		result.append(", pastWeather: ");
-		result.append(pastWeather);
-		result.append(", significantWeather: ");
-		result.append(significantWeather);
+		result.append(", significantWeather3Hours: ");
+		result.append(significantWeather3Hours);
 		result.append(", fogPropLast1: ");
 		result.append(fogPropLast1);
 		result.append(", fogPropLast6: ");

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/W1W2Impl.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/W1W2Impl.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2012 - 2024 Data In Motion and others.
+ * All rights reserved. 
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *      Mark Hoffmann - initial API and implementation
+ */
+package org.gecko.weather.model.weather.impl;
+
+import org.eclipse.emf.common.notify.Notification;
+
+import org.eclipse.emf.ecore.EClass;
+
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
+
+import org.gecko.weather.model.weather.W1W2;
+import org.gecko.weather.model.weather.WMOWeatherCodeType;
+import org.gecko.weather.model.weather.WeatherPackage;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>W1W2</b></em>'.
+ * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link org.gecko.weather.model.weather.impl.W1W2Impl#getW1 <em>W1</em>}</li>
+ *   <li>{@link org.gecko.weather.model.weather.impl.W1W2Impl#getW2 <em>W2</em>}</li>
+ * </ul>
+ *
+ * @generated
+ */
+public class W1W2Impl extends MinimalEObjectImpl.Container implements W1W2 {
+	/**
+	 * The default value of the '{@link #getW1() <em>W1</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getW1()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final WMOWeatherCodeType W1_EDEFAULT = WMOWeatherCodeType.WUNKNOWN;
+
+	/**
+	 * The cached value of the '{@link #getW1() <em>W1</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getW1()
+	 * @generated
+	 * @ordered
+	 */
+	protected WMOWeatherCodeType w1 = W1_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #getW2() <em>W2</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getW2()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final WMOWeatherCodeType W2_EDEFAULT = WMOWeatherCodeType.WUNKNOWN;
+
+	/**
+	 * The cached value of the '{@link #getW2() <em>W2</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getW2()
+	 * @generated
+	 * @ordered
+	 */
+	protected WMOWeatherCodeType w2 = W2_EDEFAULT;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected W1W2Impl() {
+		super();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	protected EClass eStaticClass() {
+		return WeatherPackage.Literals.W1W2;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public WMOWeatherCodeType getW1() {
+		return w1;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setW1(WMOWeatherCodeType newW1) {
+		WMOWeatherCodeType oldW1 = w1;
+		w1 = newW1 == null ? W1_EDEFAULT : newW1;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, WeatherPackage.W1W2__W1, oldW1, w1));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public WMOWeatherCodeType getW2() {
+		return w2;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setW2(WMOWeatherCodeType newW2) {
+		WMOWeatherCodeType oldW2 = w2;
+		w2 = newW2 == null ? W2_EDEFAULT : newW2;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, WeatherPackage.W1W2__W2, oldW2, w2));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+			case WeatherPackage.W1W2__W1:
+				return getW1();
+			case WeatherPackage.W1W2__W2:
+				return getW2();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+			case WeatherPackage.W1W2__W1:
+				setW1((WMOWeatherCodeType)newValue);
+				return;
+			case WeatherPackage.W1W2__W2:
+				setW2((WMOWeatherCodeType)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+			case WeatherPackage.W1W2__W1:
+				setW1(W1_EDEFAULT);
+				return;
+			case WeatherPackage.W1W2__W2:
+				setW2(W2_EDEFAULT);
+				return;
+		}
+		super.eUnset(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+			case WeatherPackage.W1W2__W1:
+				return w1 != W1_EDEFAULT;
+			case WeatherPackage.W1W2__W2:
+				return w2 != W2_EDEFAULT;
+		}
+		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		if (eIsProxy()) return super.toString();
+
+		StringBuilder result = new StringBuilder(super.toString());
+		result.append(" (w1: ");
+		result.append(w1);
+		result.append(", w2: ");
+		result.append(w2);
+		result.append(')');
+		return result.toString();
+	}
+
+} //W1W2Impl

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/WeatherFactoryImpl.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/WeatherFactoryImpl.java
@@ -14,6 +14,7 @@
 package org.gecko.weather.model.weather.impl;
 
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 
@@ -82,8 +83,39 @@ public class WeatherFactoryImpl extends EFactoryImpl implements WeatherFactory {
 			case WeatherPackage.MEASUREMENT_WEATHER_REPORT: return createMeasurementWeatherReport();
 			case WeatherPackage.ASTROTIME: return createAstrotime();
 			case WeatherPackage.WEATHER_STATION: return createWeatherStation();
+			case WeatherPackage.W1W2: return createW1W2();
 			default:
 				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object createFromString(EDataType eDataType, String initialValue) {
+		switch (eDataType.getClassifierID()) {
+			case WeatherPackage.WMO_WEATHER_CODE_TYPE:
+				return createWMOWeatherCodeTypeFromString(eDataType, initialValue);
+			default:
+				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String convertToString(EDataType eDataType, Object instanceValue) {
+		switch (eDataType.getClassifierID()) {
+			case WeatherPackage.WMO_WEATHER_CODE_TYPE:
+				return convertWMOWeatherCodeTypeToString(eDataType, instanceValue);
+			default:
+				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
 		}
 	}
 
@@ -250,6 +282,37 @@ public class WeatherFactoryImpl extends EFactoryImpl implements WeatherFactory {
 	public WeatherStation createWeatherStation() {
 		WeatherStationImpl weatherStation = new WeatherStationImpl();
 		return weatherStation;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public W1W2 createW1W2() {
+		W1W2Impl w1W2 = new W1W2Impl();
+		return w1W2;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public WMOWeatherCodeType createWMOWeatherCodeTypeFromString(EDataType eDataType, String initialValue) {
+		WMOWeatherCodeType result = WMOWeatherCodeType.get(initialValue);
+		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
+		return result;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String convertWMOWeatherCodeTypeToString(EDataType eDataType, Object instanceValue) {
+		return instanceValue == null ? null : instanceValue.toString();
 	}
 
 	/**

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/WeatherPackageImpl.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/WeatherPackageImpl.java
@@ -15,6 +15,7 @@ package org.gecko.weather.model.weather.impl;
 
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EEnum;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 
@@ -33,6 +34,7 @@ import org.gecko.weather.model.weather.Measurement;
 import org.gecko.weather.model.weather.MeasurementWeatherReport;
 import org.gecko.weather.model.weather.Station;
 import org.gecko.weather.model.weather.UVRadiationMeasurement;
+import org.gecko.weather.model.weather.WMOWeatherCodeType;
 import org.gecko.weather.model.weather.WeatherFactory;
 import org.gecko.weather.model.weather.WeatherPackage;
 import org.gecko.weather.model.weather.WeatherReport;
@@ -149,6 +151,20 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 	 * @generated
 	 */
 	private EClass weatherStationEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass w1W2EClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EEnum wmoWeatherCodeTypeEEnum = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
@@ -926,8 +942,8 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 	 * @generated
 	 */
 	@Override
-	public EAttribute getMOSMIXSWeatherReport_PastWeather() {
-		return (EAttribute)mosmixsWeatherReportEClass.getEStructuralFeatures().get(35);
+	public EReference getMOSMIXSWeatherReport_SignificantWeather6Hours() {
+		return (EReference)mosmixsWeatherReportEClass.getEStructuralFeatures().get(35);
 	}
 
 	/**
@@ -936,7 +952,7 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 	 * @generated
 	 */
 	@Override
-	public EAttribute getMOSMIXSWeatherReport_SignificantWeather() {
+	public EAttribute getMOSMIXSWeatherReport_SignificantWeather3Hours() {
 		return (EAttribute)mosmixsWeatherReportEClass.getEStructuralFeatures().get(36);
 	}
 
@@ -1076,6 +1092,46 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 	 * @generated
 	 */
 	@Override
+	public EClass getW1W2() {
+		return w1W2EClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EAttribute getW1W2_W1() {
+		return (EAttribute)w1W2EClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EAttribute getW1W2_W2() {
+		return (EAttribute)w1W2EClass.getEStructuralFeatures().get(1);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EEnum getWMOWeatherCodeType() {
+		return wmoWeatherCodeTypeEEnum;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public WeatherFactory getWeatherFactory() {
 		return (WeatherFactory)getEFactoryInstance();
 	}
@@ -1181,8 +1237,8 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 		createEAttribute(mosmixsWeatherReportEClass, MOSMIXS_WEATHER_REPORT__TEMP_MIN_LAST12);
 		createEAttribute(mosmixsWeatherReportEClass, MOSMIXS_WEATHER_REPORT__TEMP_MAX_LAST12);
 		createEAttribute(mosmixsWeatherReportEClass, MOSMIXS_WEATHER_REPORT__VISIBILITY);
-		createEAttribute(mosmixsWeatherReportEClass, MOSMIXS_WEATHER_REPORT__PAST_WEATHER);
-		createEAttribute(mosmixsWeatherReportEClass, MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER);
+		createEReference(mosmixsWeatherReportEClass, MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER6_HOURS);
+		createEAttribute(mosmixsWeatherReportEClass, MOSMIXS_WEATHER_REPORT__SIGNIFICANT_WEATHER3_HOURS);
 		createEAttribute(mosmixsWeatherReportEClass, MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST1);
 		createEAttribute(mosmixsWeatherReportEClass, MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST6);
 		createEAttribute(mosmixsWeatherReportEClass, MOSMIXS_WEATHER_REPORT__FOG_PROP_LAST12);
@@ -1199,6 +1255,13 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 		weatherStationEClass = createEClass(WEATHER_STATION);
 		createEAttribute(weatherStationEClass, WEATHER_STATION__ID);
 		createEAttribute(weatherStationEClass, WEATHER_STATION__ICAO_CODE);
+
+		w1W2EClass = createEClass(W1W2);
+		createEAttribute(w1W2EClass, W1W2__W1);
+		createEAttribute(w1W2EClass, W1W2__W2);
+
+		// Create enums
+		wmoWeatherCodeTypeEEnum = createEEnum(WMO_WEATHER_CODE_TYPE);
 	}
 
 	/**
@@ -1323,8 +1386,8 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 		initEAttribute(getMOSMIXSWeatherReport_TempMinLast12(), ecorePackage.getEFloatObject(), "tempMinLast12", null, 0, 1, MOSMIXSWeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getMOSMIXSWeatherReport_TempMaxLast12(), ecorePackage.getEFloatObject(), "tempMaxLast12", null, 0, 1, MOSMIXSWeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getMOSMIXSWeatherReport_Visibility(), ecorePackage.getEFloatObject(), "visibility", null, 0, 1, MOSMIXSWeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEAttribute(getMOSMIXSWeatherReport_PastWeather(), ecorePackage.getEFloatObject(), "pastWeather", null, 0, 1, MOSMIXSWeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEAttribute(getMOSMIXSWeatherReport_SignificantWeather(), ecorePackage.getEFloatObject(), "significantWeather", null, 0, 1, MOSMIXSWeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getMOSMIXSWeatherReport_SignificantWeather6Hours(), this.getW1W2(), null, "significantWeather6Hours", null, 0, 1, MOSMIXSWeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getMOSMIXSWeatherReport_SignificantWeather3Hours(), this.getWMOWeatherCodeType(), "significantWeather3Hours", "UNKNOWN", 0, 1, MOSMIXSWeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getMOSMIXSWeatherReport_FogPropLast1(), ecorePackage.getEFloatObject(), "fogPropLast1", null, 0, 1, MOSMIXSWeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getMOSMIXSWeatherReport_FogPropLast6(), ecorePackage.getEFloatObject(), "fogPropLast6", null, 0, 1, MOSMIXSWeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getMOSMIXSWeatherReport_FogPropLast12(), ecorePackage.getEFloatObject(), "fogPropLast12", null, 0, 1, MOSMIXSWeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -1341,6 +1404,86 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 		initEClass(weatherStationEClass, WeatherStation.class, "WeatherStation", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getWeatherStation_Id(), ecorePackage.getEString(), "id", null, 1, 1, WeatherStation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getWeatherStation_IcaoCode(), ecorePackage.getEString(), "icaoCode", null, 0, 1, WeatherStation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(w1W2EClass, org.gecko.weather.model.weather.W1W2.class, "W1W2", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getW1W2_W1(), this.getWMOWeatherCodeType(), "w1", "UNKNOWN", 0, 1, org.gecko.weather.model.weather.W1W2.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getW1W2_W2(), this.getWMOWeatherCodeType(), "w2", "UNKNOWN", 0, 1, org.gecko.weather.model.weather.W1W2.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		// Initialize enums and add enum literals
+		initEEnum(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.class, "WMOWeatherCodeType");
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W00);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W01);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W02);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W03);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W04);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W05);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W10);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W20);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W21);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W22);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W23);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W24);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W25);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W26);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W27);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W28);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W29);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W30);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W31);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W32);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W33);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W34);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W35);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W40);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W41);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W42);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W43);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W44);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W45);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W50);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W51);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W52);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W53);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W54);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W55);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W56);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W57);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W58);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W60);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W61);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W62);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W63);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W64);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W65);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W66);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W67);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W68);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W70);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W71);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W72);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W73);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W74);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W75);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W76);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W77);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W80);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W81);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W82);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W83);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W85);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W86);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W87);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W90);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W91);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W92);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W93);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W94);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W95);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W96);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W97);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W98);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.W99);
+		addEEnumLiteral(wmoWeatherCodeTypeEEnum, WMOWeatherCodeType.WUNKNOWN);
 
 		// Create resource
 		createResource(eNS_URI);
@@ -1603,16 +1746,16 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 			   "documentation", "Visibility: m (VV)"
 		   });
 		addAnnotation
-		  (getMOSMIXSWeatherReport_PastWeather(),
+		  (getMOSMIXSWeatherReport_SignificantWeather6Hours(),
 		   source,
 		   new String[] {
-			   "documentation", "Past weather during the last 6 hours: - (W1W2)"
+			   "documentation", "Significant weather during the last 6 hours. It encodes significant weather for two consecutive 3-hour intervals in the past 6 hours: - (W1W2)"
 		   });
 		addAnnotation
-		  (getMOSMIXSWeatherReport_SignificantWeather(),
+		  (getMOSMIXSWeatherReport_SignificantWeather3Hours(),
 		   source,
 		   new String[] {
-			   "documentation", "Significant Weather: - (ww)"
+			   "documentation", "Significant weather during the past 3 hours: - (ww)"
 		   });
 		addAnnotation
 		  (getMOSMIXSWeatherReport_FogPropLast1(),
@@ -1661,6 +1804,456 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 		   source,
 		   new String[] {
 			   "documentation", "Internation Civil Aviation Organization code"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(0),
+		   source,
+		   new String[] {
+			   "documentation", "No change in cloud cover (MOSMIX-specific)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(1),
+		   source,
+		   new String[] {
+			   "documentation", "Cloudiness is decreasing (MOSMIX-specific)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(2),
+		   source,
+		   new String[] {
+			   "documentation", "Cloudiness remains unchanged (MOSMIX-specific)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(3),
+		   source,
+		   new String[] {
+			   "documentation", "Cloudiness is increasing (MOSMIX-specific)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(4),
+		   source,
+		   new String[] {
+			   "documentation", "Haze, smoke, dust, visibility \u2265 1 km"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(5),
+		   source,
+		   new String[] {
+			   "documentation", "Haze, smoke, dust, visibility < 1 km"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(6),
+		   source,
+		   new String[] {
+			   "documentation", "Mist"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(7),
+		   source,
+		   new String[] {
+			   "documentation", "Fog"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(8),
+		   source,
+		   new String[] {
+			   "documentation", "Precipitation (recent, unspecified)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(9),
+		   source,
+		   new String[] {
+			   "documentation", "Drizzle or snow grains (recent)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(10),
+		   source,
+		   new String[] {
+			   "documentation", "Rain (recent)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(11),
+		   source,
+		   new String[] {
+			   "documentation", "Snow (recent)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(12),
+		   source,
+		   new String[] {
+			   "documentation", "Freezing rain/drizzle (recent)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(13),
+		   source,
+		   new String[] {
+			   "documentation", "Thunderstorm (recent)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(14),
+		   source,
+		   new String[] {
+			   "documentation", "Blowing snow or sand (recent)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(15),
+		   source,
+		   new String[] {
+			   "documentation", "Blowing snow/sand, V \u2265 1 km (recent)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(16),
+		   source,
+		   new String[] {
+			   "documentation", "Blowing snow/sand, V < 1 km (recent)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(17),
+		   source,
+		   new String[] {
+			   "documentation", "Fog"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(18),
+		   source,
+		   new String[] {
+			   "documentation", "Patches of fog"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(19),
+		   source,
+		   new String[] {
+			   "documentation", "Fog \u2014 thinning"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(20),
+		   source,
+		   new String[] {
+			   "documentation", "Fog \u2014 no change"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(21),
+		   source,
+		   new String[] {
+			   "documentation", "Fog \u2014 thickening"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(22),
+		   source,
+		   new String[] {
+			   "documentation", "Rime fog"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(23),
+		   source,
+		   new String[] {
+			   "documentation", "Precipitation (present, unspecified)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(24),
+		   source,
+		   new String[] {
+			   "documentation", "Precipitation slight/moderate"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(25),
+		   source,
+		   new String[] {
+			   "documentation", "Precipitation heavy"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(26),
+		   source,
+		   new String[] {
+			   "documentation", "Liquid precipitation slight/mod"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(27),
+		   source,
+		   new String[] {
+			   "documentation", "Liquid precipitation heavy"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(28),
+		   source,
+		   new String[] {
+			   "documentation", "Solid precipitation slight/mod"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(29),
+		   source,
+		   new String[] {
+			   "documentation", "Drizzle"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(30),
+		   source,
+		   new String[] {
+			   "documentation", "Drizzle slight"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(31),
+		   source,
+		   new String[] {
+			   "documentation", "Drizzle moderate"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(32),
+		   source,
+		   new String[] {
+			   "documentation", "Drizzle heavy"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(33),
+		   source,
+		   new String[] {
+			   "documentation", "Freezing drizzle slight"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(34),
+		   source,
+		   new String[] {
+			   "documentation", "Freezing drizzle moderate"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(35),
+		   source,
+		   new String[] {
+			   "documentation", "Freezing drizzle heavy"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(36),
+		   source,
+		   new String[] {
+			   "documentation", "Drizzle & rain slight"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(37),
+		   source,
+		   new String[] {
+			   "documentation", "Drizzle & rain mod/heavy"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(38),
+		   source,
+		   new String[] {
+			   "documentation", "Rain"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(39),
+		   source,
+		   new String[] {
+			   "documentation", "Rain slight"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(40),
+		   source,
+		   new String[] {
+			   "documentation", "Rain moderate"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(41),
+		   source,
+		   new String[] {
+			   "documentation", "Rain heavy"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(42),
+		   source,
+		   new String[] {
+			   "documentation", "Freezing rain slight"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(43),
+		   source,
+		   new String[] {
+			   "documentation", "Freezing rain moderate"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(44),
+		   source,
+		   new String[] {
+			   "documentation", "Freezing rain heavy"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(45),
+		   source,
+		   new String[] {
+			   "documentation", "Rain + snow (or drizzle) slight"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(46),
+		   source,
+		   new String[] {
+			   "documentation", "Rain + snow mod/heavy"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(47),
+		   source,
+		   new String[] {
+			   "documentation", "Snow"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(48),
+		   source,
+		   new String[] {
+			   "documentation", "Snow slight"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(49),
+		   source,
+		   new String[] {
+			   "documentation", "Snow moderate"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(50),
+		   source,
+		   new String[] {
+			   "documentation", "Snow heavy"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(51),
+		   source,
+		   new String[] {
+			   "documentation", "Ice pellets slight"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(52),
+		   source,
+		   new String[] {
+			   "documentation", "Ice pellets moderate"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(53),
+		   source,
+		   new String[] {
+			   "documentation", "Ice pellets heavy"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(54),
+		   source,
+		   new String[] {
+			   "documentation", "Snow grains"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(55),
+		   source,
+		   new String[] {
+			   "documentation", "Showers"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(56),
+		   source,
+		   new String[] {
+			   "documentation", "Rain showers slight"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(57),
+		   source,
+		   new String[] {
+			   "documentation", "Rain showers moderate"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(58),
+		   source,
+		   new String[] {
+			   "documentation", "Rain showers heavy"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(59),
+		   source,
+		   new String[] {
+			   "documentation", "Snow showers slight"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(60),
+		   source,
+		   new String[] {
+			   "documentation", "Snow showers moderate"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(61),
+		   source,
+		   new String[] {
+			   "documentation", "Snow showers heavy"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(62),
+		   source,
+		   new String[] {
+			   "documentation", "Hail showers (no thunder)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(63),
+		   source,
+		   new String[] {
+			   "documentation", "Thunderstorm recent + slight rain"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(64),
+		   source,
+		   new String[] {
+			   "documentation", "Thunderstorm recent + mod/heavy rain"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(65),
+		   source,
+		   new String[] {
+			   "documentation", "Thunderstorm recent + slight snow/hail"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(66),
+		   source,
+		   new String[] {
+			   "documentation", "Thunderstorm recent + mod/heavy snow/hail"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(67),
+		   source,
+		   new String[] {
+			   "documentation", "Thunderstorm, no hail (slight or moderate)"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(68),
+		   source,
+		   new String[] {
+			   "documentation", "Thunderstorm with slight hail"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(69),
+		   source,
+		   new String[] {
+			   "documentation", "Thunderstorm, heavy, no hail"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(70),
+		   source,
+		   new String[] {
+			   "documentation", "Thunderstorm with dust or sandstorm"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(71),
+		   source,
+		   new String[] {
+			   "documentation", "Thunderstorm with heavy hail"
+		   });
+		addAnnotation
+		  (wmoWeatherCodeTypeEEnum.getELiterals().get(72),
+		   source,
+		   new String[] {
+			   "documentation", "No value was set"
+		   });
+		addAnnotation
+		  (getW1W2_W1(),
+		   source,
+		   new String[] {
+			   "documentation", "Significant weather in the past 6 to 3 hours: - (W1 part of W1W2)"
+		   });
+		addAnnotation
+		  (getW1W2_W2(),
+		   source,
+		   new String[] {
+			   "documentation", "Significant weather in the past 3 hours: - (W2 part of W1W2)"
 		   });
 	}
 

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/util/WeatherAdapterFactory.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/util/WeatherAdapterFactory.java
@@ -139,6 +139,10 @@ public class WeatherAdapterFactory extends AdapterFactoryImpl {
 				return createWeatherStationAdapter();
 			}
 			@Override
+			public Adapter caseW1W2(W1W2 object) {
+				return createW1W2Adapter();
+			}
+			@Override
 			public Adapter defaultCase(EObject object) {
 				return createEObjectAdapter();
 			}
@@ -365,6 +369,20 @@ public class WeatherAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	public Adapter createWeatherStationAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.gecko.weather.model.weather.W1W2 <em>W1W2</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.gecko.weather.model.weather.W1W2
+	 * @generated
+	 */
+	public Adapter createW1W2Adapter() {
 		return null;
 	}
 

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/util/WeatherSwitch.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/util/WeatherSwitch.java
@@ -177,6 +177,12 @@ public class WeatherSwitch<T> extends Switch<T> {
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
+			case WeatherPackage.W1W2: {
+				W1W2 w1W2 = (W1W2)theEObject;
+				T result = caseW1W2(w1W2);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
 			default: return defaultCase(theEObject);
 		}
 	}
@@ -403,6 +409,21 @@ public class WeatherSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	public T caseWeatherStation(WeatherStation object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>W1W2</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>W1W2</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseW1W2(W1W2 object) {
 		return null;
 	}
 


### PR DESCRIPTION
+ The `significantWeather` attribute in the `MOSMIXWeatherReport` is now called `significantWeather3Hours` and the `pastWeather` is called `significantWeather6Hours`
+ Documentation annotation has been updated
+ Their values are not `EFloatObject` but `EEnum` of type `WMOWeatherCodeType`
+ The  `significantWeather6Hours` is actually a complex object `W1W2` where the two parts are of type `WMOWeatherCodeType`
+ Documentation has been added in the model repo under `SignificantWeatherDocs.md`
+ Changes in the `DWDUtils` have been made to properly set these features