### PR TITLE
added issue time to report in the model and set it in fetcher

### DIFF
--- a/org.gecko.weather.dwd.forecast/src/org/gecko/weather/dwd/fc/impl/DWDMOSMIXStationForecastFetcher.java
+++ b/org.gecko.weather.dwd.forecast/src/org/gecko/weather/dwd/fc/impl/DWDMOSMIXStationForecastFetcher.java
@@ -193,6 +193,8 @@ public class DWDMOSMIXStationForecastFetcher extends DWDEMFFetcher<KmlType> impl
 		List<ProductDefinitionType> productDefinitions = (List<ProductDefinitionType>) extendedData.getAny()
 				.get(forecastPackage.getDocumentRoot_ProductDefinition(), true);
 		if (nonNull(productDefinitions) && !productDefinitions.isEmpty()) {
+			XMLGregorianCalendar issueTime = productDefinitions.get(0).getIssueTime();
+			GregorianCalendar issueTimeGC = issueTime.toGregorianCalendar();
 			EList<XMLGregorianCalendar> forecastTimeSteps = productDefinitions.get(0).getForecastTimeSteps()
 					.getTimeStep();
 			LOGGER.log(Level.DEBUG, "[{0}] MOSMIX Timesteps: {1}", getName(), forecastTimeSteps.size());
@@ -205,6 +207,7 @@ public class DWDMOSMIXStationForecastFetcher extends DWDEMFFetcher<KmlType> impl
 				XMLGregorianCalendar xmlC = forecastTimeSteps.get(i);
 				GregorianCalendar c = xmlC.toGregorianCalendar();
 				report.setTimestamp(c.getTime());
+				report.setIssueTime(issueTimeGC.getTime());
 				if(location != null) {
 					Astrotime sunTimes = as.getSunTimes(location, LocalDate.ofInstant(c.getTime().toInstant(), ZoneId.systemDefault()));
 					report.setAstrotime(sunTimes);
@@ -212,6 +215,7 @@ public class DWDMOSMIXStationForecastFetcher extends DWDEMFFetcher<KmlType> impl
 				reports[i] = report;
 			}
 		}
+		
 		extendedData = placemarkType.getExtendedData();
 		List<ForecastType> forecasts = (List<ForecastType>) extendedData.getAny()
 				.get(forecastPackage.getDocumentRoot_Forecast(), true);

--- a/org.gecko.weather.dwd.forecast/src/org/gecko/weather/dwd/fc/impl/WeatherReportIndexServiceWithFilter.java
+++ b/org.gecko.weather.dwd.forecast/src/org/gecko/weather/dwd/fc/impl/WeatherReportIndexServiceWithFilter.java
@@ -227,7 +227,7 @@ public class WeatherReportIndexServiceWithFilter implements WeatherReportIndex {
 					id = ReportHelper.createReportId(report);
 					report.setId(id);
 				}
-				weatherReports.setId(report.getWeatherStation().getId());
+				if(weatherReports.getId() == null) weatherReports.setId(report.getWeatherStation().getId());
 				weatherReports.getReports().add(report);			
 			}
 		}

--- a/org.gecko.weather.model/model/dwd-weather.ecore
+++ b/org.gecko.weather.model/model/dwd-weather.ecore
@@ -18,8 +18,18 @@
   <eClassifiers xsi:type="ecore:EClass" name="WeatherReport">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
         iD="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="issueTime" lowerBound="1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDate">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="This is the time the report was issued."/>
+      </eAnnotations>
+    </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="timestamp" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDate"/>
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDate">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="This is the time to which the report refers. So, if it is a forecast for a certain time, the forecasted time will be here."/>
+      </eAnnotations>
+    </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EReference" name="station" lowerBound="1"
         eType="#//Station" containment="true" eKeys="#//Station/name">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">

--- a/org.gecko.weather.model/model/dwd-weather.genmodel
+++ b/org.gecko.weather.model/model/dwd-weather.genmodel
@@ -90,6 +90,7 @@
     </genClasses>
     <genClasses ecoreClass="dwd-weather.ecore#//WeatherReport">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//WeatherReport/id"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//WeatherReport/issueTime"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute dwd-weather.ecore#//WeatherReport/timestamp"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference dwd-weather.ecore#//WeatherReport/station"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference dwd-weather.ecore#//WeatherReport/astrotime"/>

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/WeatherPackage.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/WeatherPackage.java
@@ -150,13 +150,22 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 	int WEATHER_REPORT__ID = 0;
 
 	/**
+	 * The feature id for the '<em><b>Issue Time</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int WEATHER_REPORT__ISSUE_TIME = 1;
+
+	/**
 	 * The feature id for the '<em><b>Timestamp</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int WEATHER_REPORT__TIMESTAMP = 1;
+	int WEATHER_REPORT__TIMESTAMP = 2;
 
 	/**
 	 * The feature id for the '<em><b>Station</b></em>' containment reference.
@@ -165,7 +174,7 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int WEATHER_REPORT__STATION = 2;
+	int WEATHER_REPORT__STATION = 3;
 
 	/**
 	 * The feature id for the '<em><b>Astrotime</b></em>' containment reference.
@@ -174,7 +183,7 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int WEATHER_REPORT__ASTROTIME = 3;
+	int WEATHER_REPORT__ASTROTIME = 4;
 
 	/**
 	 * The feature id for the '<em><b>Weather Station</b></em>' reference.
@@ -183,7 +192,7 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int WEATHER_REPORT__WEATHER_STATION = 4;
+	int WEATHER_REPORT__WEATHER_STATION = 5;
 
 	/**
 	 * The number of structural features of the '<em>Report</em>' class.
@@ -192,7 +201,7 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int WEATHER_REPORT_FEATURE_COUNT = 5;
+	int WEATHER_REPORT_FEATURE_COUNT = 6;
 
 	/**
 	 * The number of operations of the '<em>Report</em>' class.
@@ -844,6 +853,15 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 	int MOSMIXS_WEATHER_REPORT__ID = WEATHER_REPORT__ID;
 
 	/**
+	 * The feature id for the '<em><b>Issue Time</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MOSMIXS_WEATHER_REPORT__ISSUE_TIME = WEATHER_REPORT__ISSUE_TIME;
+
+	/**
 	 * The feature id for the '<em><b>Timestamp</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1277,6 +1295,15 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 	int MEASUREMENT_WEATHER_REPORT__ID = WEATHER_REPORT__ID;
 
 	/**
+	 * The feature id for the '<em><b>Issue Time</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MEASUREMENT_WEATHER_REPORT__ISSUE_TIME = WEATHER_REPORT__ISSUE_TIME;
+
+	/**
 	 * The feature id for the '<em><b>Timestamp</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1642,6 +1669,17 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 	 * @generated
 	 */
 	EAttribute getWeatherReport_Id();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.gecko.weather.model.weather.WeatherReport#getIssueTime <em>Issue Time</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Issue Time</em>'.
+	 * @see org.gecko.weather.model.weather.WeatherReport#getIssueTime()
+	 * @see #getWeatherReport()
+	 * @generated
+	 */
+	EAttribute getWeatherReport_IssueTime();
 
 	/**
 	 * Returns the meta object for the attribute '{@link org.gecko.weather.model.weather.WeatherReport#getTimestamp <em>Timestamp</em>}'.
@@ -2658,6 +2696,14 @@ public interface WeatherPackage extends org.eclipse.emf.ecore.EPackage {
 		 * @generated
 		 */
 		EAttribute WEATHER_REPORT__ID = eINSTANCE.getWeatherReport_Id();
+
+		/**
+		 * The meta object literal for the '<em><b>Issue Time</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute WEATHER_REPORT__ISSUE_TIME = eINSTANCE.getWeatherReport_IssueTime();
 
 		/**
 		 * The meta object literal for the '<em><b>Timestamp</b></em>' attribute feature.

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/WeatherReport.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/WeatherReport.java
@@ -29,6 +29,7 @@ import org.osgi.annotation.versioning.ProviderType;
  * </p>
  * <ul>
  *   <li>{@link org.gecko.weather.model.weather.WeatherReport#getId <em>Id</em>}</li>
+ *   <li>{@link org.gecko.weather.model.weather.WeatherReport#getIssueTime <em>Issue Time</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.WeatherReport#getTimestamp <em>Timestamp</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.WeatherReport#getStation <em>Station</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.WeatherReport#getAstrotime <em>Astrotime</em>}</li>
@@ -64,9 +65,37 @@ public interface WeatherReport extends EObject {
 	void setId(String value);
 
 	/**
+	 * Returns the value of the '<em><b>Issue Time</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * This is the time the report was issued.
+	 * <!-- end-model-doc -->
+	 * @return the value of the '<em>Issue Time</em>' attribute.
+	 * @see #setIssueTime(Date)
+	 * @see org.gecko.weather.model.weather.WeatherPackage#getWeatherReport_IssueTime()
+	 * @model required="true"
+	 * @generated
+	 */
+	Date getIssueTime();
+
+	/**
+	 * Sets the value of the '{@link org.gecko.weather.model.weather.WeatherReport#getIssueTime <em>Issue Time</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Issue Time</em>' attribute.
+	 * @see #getIssueTime()
+	 * @generated
+	 */
+	void setIssueTime(Date value);
+
+	/**
 	 * Returns the value of the '<em><b>Timestamp</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * This is the time to which the report refers. So, if it is a forecast for a certain time, the forecasted time will be here.
+	 * <!-- end-model-doc -->
 	 * @return the value of the '<em>Timestamp</em>' attribute.
 	 * @see #setTimestamp(Date)
 	 * @see org.gecko.weather.model.weather.WeatherPackage#getWeatherReport_Timestamp()

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/WeatherPackageImpl.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/WeatherPackageImpl.java
@@ -300,7 +300,7 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 	 * @generated
 	 */
 	@Override
-	public EAttribute getWeatherReport_Timestamp() {
+	public EAttribute getWeatherReport_IssueTime() {
 		return (EAttribute)weatherReportEClass.getEStructuralFeatures().get(1);
 	}
 
@@ -310,8 +310,8 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 	 * @generated
 	 */
 	@Override
-	public EReference getWeatherReport_Station() {
-		return (EReference)weatherReportEClass.getEStructuralFeatures().get(2);
+	public EAttribute getWeatherReport_Timestamp() {
+		return (EAttribute)weatherReportEClass.getEStructuralFeatures().get(2);
 	}
 
 	/**
@@ -320,7 +320,7 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 	 * @generated
 	 */
 	@Override
-	public EReference getWeatherReport_Astrotime() {
+	public EReference getWeatherReport_Station() {
 		return (EReference)weatherReportEClass.getEStructuralFeatures().get(3);
 	}
 
@@ -330,8 +330,18 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 	 * @generated
 	 */
 	@Override
-	public EReference getWeatherReport_WeatherStation() {
+	public EReference getWeatherReport_Astrotime() {
 		return (EReference)weatherReportEClass.getEStructuralFeatures().get(4);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EReference getWeatherReport_WeatherStation() {
+		return (EReference)weatherReportEClass.getEStructuralFeatures().get(5);
 	}
 
 	/**
@@ -1200,6 +1210,7 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 
 		weatherReportEClass = createEClass(WEATHER_REPORT);
 		createEAttribute(weatherReportEClass, WEATHER_REPORT__ID);
+		createEAttribute(weatherReportEClass, WEATHER_REPORT__ISSUE_TIME);
 		createEAttribute(weatherReportEClass, WEATHER_REPORT__TIMESTAMP);
 		createEReference(weatherReportEClass, WEATHER_REPORT__STATION);
 		createEReference(weatherReportEClass, WEATHER_REPORT__ASTROTIME);
@@ -1352,6 +1363,7 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 
 		initEClass(weatherReportEClass, WeatherReport.class, "WeatherReport", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getWeatherReport_Id(), ecorePackage.getEString(), "id", null, 1, 1, WeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getWeatherReport_IssueTime(), ecorePackage.getEDate(), "issueTime", null, 1, 1, WeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getWeatherReport_Timestamp(), ecorePackage.getEDate(), "timestamp", null, 1, 1, WeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getWeatherReport_Station(), this.getStation(), null, "station", null, 1, 1, WeatherReport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		getWeatherReport_Station().getEKeys().add(this.getStation_Name());
@@ -1557,6 +1569,18 @@ public class WeatherPackageImpl extends EPackageImpl implements WeatherPackage {
 			   "modelName", "DWDWeather",
 			   "basePackage", "org.gecko.weather.model",
 			   "resource", "XMI"
+		   });
+		addAnnotation
+		  (getWeatherReport_IssueTime(),
+		   source,
+		   new String[] {
+			   "documentation", "This is the time the report was issued."
+		   });
+		addAnnotation
+		  (getWeatherReport_Timestamp(),
+		   source,
+		   new String[] {
+			   "documentation", "This is the time to which the report refers. So, if it is a forecast for a certain time, the forecasted time will be here."
 		   });
 		addAnnotation
 		  (getWeatherReport_Station(),

--- a/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/WeatherReportImpl.java
+++ b/org.gecko.weather.model/src/org/gecko/weather/model/weather/impl/WeatherReportImpl.java
@@ -39,6 +39,7 @@ import org.gecko.weather.model.weather.WeatherStation;
  * </p>
  * <ul>
  *   <li>{@link org.gecko.weather.model.weather.impl.WeatherReportImpl#getId <em>Id</em>}</li>
+ *   <li>{@link org.gecko.weather.model.weather.impl.WeatherReportImpl#getIssueTime <em>Issue Time</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.impl.WeatherReportImpl#getTimestamp <em>Timestamp</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.impl.WeatherReportImpl#getStation <em>Station</em>}</li>
  *   <li>{@link org.gecko.weather.model.weather.impl.WeatherReportImpl#getAstrotime <em>Astrotime</em>}</li>
@@ -67,6 +68,26 @@ public class WeatherReportImpl extends MinimalEObjectImpl.Container implements W
 	 * @ordered
 	 */
 	protected String id = ID_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #getIssueTime() <em>Issue Time</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getIssueTime()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final Date ISSUE_TIME_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getIssueTime() <em>Issue Time</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getIssueTime()
+	 * @generated
+	 * @ordered
+	 */
+	protected Date issueTime = ISSUE_TIME_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getTimestamp() <em>Timestamp</em>}' attribute.
@@ -158,6 +179,29 @@ public class WeatherReportImpl extends MinimalEObjectImpl.Container implements W
 		id = newId;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, WeatherPackage.WEATHER_REPORT__ID, oldId, id));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Date getIssueTime() {
+		return issueTime;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setIssueTime(Date newIssueTime) {
+		Date oldIssueTime = issueTime;
+		issueTime = newIssueTime;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, WeatherPackage.WEATHER_REPORT__ISSUE_TIME, oldIssueTime, issueTime));
 	}
 
 	/**
@@ -339,6 +383,8 @@ public class WeatherReportImpl extends MinimalEObjectImpl.Container implements W
 		switch (featureID) {
 			case WeatherPackage.WEATHER_REPORT__ID:
 				return getId();
+			case WeatherPackage.WEATHER_REPORT__ISSUE_TIME:
+				return getIssueTime();
 			case WeatherPackage.WEATHER_REPORT__TIMESTAMP:
 				return getTimestamp();
 			case WeatherPackage.WEATHER_REPORT__STATION:
@@ -362,6 +408,9 @@ public class WeatherReportImpl extends MinimalEObjectImpl.Container implements W
 		switch (featureID) {
 			case WeatherPackage.WEATHER_REPORT__ID:
 				setId((String)newValue);
+				return;
+			case WeatherPackage.WEATHER_REPORT__ISSUE_TIME:
+				setIssueTime((Date)newValue);
 				return;
 			case WeatherPackage.WEATHER_REPORT__TIMESTAMP:
 				setTimestamp((Date)newValue);
@@ -390,6 +439,9 @@ public class WeatherReportImpl extends MinimalEObjectImpl.Container implements W
 			case WeatherPackage.WEATHER_REPORT__ID:
 				setId(ID_EDEFAULT);
 				return;
+			case WeatherPackage.WEATHER_REPORT__ISSUE_TIME:
+				setIssueTime(ISSUE_TIME_EDEFAULT);
+				return;
 			case WeatherPackage.WEATHER_REPORT__TIMESTAMP:
 				setTimestamp(TIMESTAMP_EDEFAULT);
 				return;
@@ -416,6 +468,8 @@ public class WeatherReportImpl extends MinimalEObjectImpl.Container implements W
 		switch (featureID) {
 			case WeatherPackage.WEATHER_REPORT__ID:
 				return ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
+			case WeatherPackage.WEATHER_REPORT__ISSUE_TIME:
+				return ISSUE_TIME_EDEFAULT == null ? issueTime != null : !ISSUE_TIME_EDEFAULT.equals(issueTime);
 			case WeatherPackage.WEATHER_REPORT__TIMESTAMP:
 				return TIMESTAMP_EDEFAULT == null ? timestamp != null : !TIMESTAMP_EDEFAULT.equals(timestamp);
 			case WeatherPackage.WEATHER_REPORT__STATION:
@@ -440,6 +494,8 @@ public class WeatherReportImpl extends MinimalEObjectImpl.Container implements W
 		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (id: ");
 		result.append(id);
+		result.append(", issueTime: ");
+		result.append(issueTime);
 		result.append(", timestamp: ");
 		result.append(timestamp);
 		result.append(')');


### PR DESCRIPTION
We currently were not storing the issue time of a report, meaning the time in which this report has been produced by the dwd. 
That can be a useful information as well.
So I added it in the model and I am setting it in the forecast fetcher.